### PR TITLE
Fix issues in .hocon files reported by the new neuro-san agent network validator

### DIFF
--- a/registries/kyoto_protocol.hocon
+++ b/registries/kyoto_protocol.hocon
@@ -127,7 +127,7 @@ Load the document and read it carefully before answering.
         tools = ["ThirteenthSessionDecisionsDocument"]
     }
     {
-        name = "ThirteenSessionDecisionsDocument"
+        name = "ThirteenthSessionDecisionsDocument"
         toolbox = "txt_loader"
         args = {
             # File path is relative to the root directory of the repo.

--- a/registries/paris_agreement.hocon
+++ b/registries/paris_agreement.hocon
@@ -123,7 +123,7 @@ Use your tool to load the document and read it carefully before answering.
         }
     }
     {
-        name = "CMA_1_3_Add.2"
+        name = "CMA_1_3_Add_2"
         function = ${aaosa_call}
         instructions =
 """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Neuro SAN
-neuro-san==0.5.62
-nsflow==0.5.20
+neuro-san==0.5.68
+nsflow==0.6.1
 
 # For the airline_policy demo and agentic rag, to extract text from documents
 pypdf>=5.4.0


### PR DESCRIPTION
- Upgraded to neuro-san `0.5.68
- Upgrade to nsflow `0.6.1`
- Fixed the issues reported by the agent network validator at startup time:

```
NeuroSan: ["Agent 'ThirteenthSessionDecisions' references non-existent agent(s) in tools: 'ThirteenthSessionDecisionsDocument'"]
NeuroSan: ["Unreachable agents found: ['ThirteenSessionDecisionsDocument']"]
NeuroSan: manifest registry kyoto_protocol.hocon has validation errors. Skipping. Errors: [
NeuroSan: "Agent 'ThirteenthSessionDecisions' references non-existent agent(s) in tools: 'ThirteenthSessionDecisionsDocument'",
NeuroSan: "Unreachable agents found: ['ThirteenSessionDecisionsDocument']"
NeuroSan: ]
NeuroSan: ["Agent 'CMA_1' references non-existent agent(s) in tools: 'CMA_1_3_Add_2'"]
NeuroSan: ["Multiple top agents found: ['CMA_1_3_Add.2', 'ParisAgreement']. Expected exactly one."]
NeuroSan: ["CMA_1_3_Add.2 must match the regex '^[a-zA-Z0-9_-]+$'"]
NeuroSan: manifest registry paris_agreement.hocon has validation errors. Skipping. Errors: [
NeuroSan: "Agent 'CMA_1' references non-existent agent(s) in tools: 'CMA_1_3_Add_2'",
NeuroSan: "Multiple top agents found: ['CMA_1_3_Add.2', 'ParisAgreement']. Expected exactly one.",
NeuroSan: "CMA_1_3_Add.2 must match the regex '^[a-zA-Z0-9_-]+$'"
NeuroSan: ]
```