### PR TITLE
Fix pylint issues in Graph RAG code

### DIFF
--- a/coded_tools/graph_rag/__init__.py
+++ b/coded_tools/graph_rag/__init__.py
@@ -13,6 +13,5 @@ Graph RAG coded tools.
 """
 
 from .graph_search_tool import GraphSearchTool
-from .postgres_search_tool import PostgresSearchTool
 
-__all__ = ["PostgresSearchTool", "GraphSearchTool"]
+__all__ = ["GraphSearchTool"]

--- a/coded_tools/graph_rag/__init__.py
+++ b/coded_tools/graph_rag/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san-studio SDK Software in commercial settings.
+#
+
+"""
+Graph RAG coded tools.
+"""
+
+from .graph_search_tool import GraphSearchTool
+from .postgres_search_tool import PostgresSearchTool
+
+__all__ = ["PostgresSearchTool", "GraphSearchTool"]

--- a/coded_tools/graph_rag/constrained_prompts.py
+++ b/coded_tools/graph_rag/constrained_prompts.py
@@ -335,6 +335,33 @@ Extract ALL relationships:
 - IPCC PROVIDES special reports
 - special reports RELATES_TO 1.5°C goal
 
+## CRITICAL: FOUNDING vs FOLLOW-UP DISTINCTION
+When extracting relationships, distinguish between CREATION and FOLLOW-UP actions:
+
+FOUNDING relationships (use these relation_types):
+- ESTABLISHES: "Establishes the Santiago network", "Decides to establish a committee"
+- CREATES: "Creates a new fund", "Sets up a mechanism"
+- LAUNCHES: "Launches the Koronivia joint work"
+→ Set valid_at to the decision's reference_time (marks creation date)
+
+FOLLOW-UP relationships (use these relation_types):
+- FURTHER_DEVELOPS: "Further develops the institutional arrangements"
+- EXPANDS: "Decides that [X] shall have the following functions"
+- OPERATIONALIZES: "Operationalizes the network by defining its structure"
+- REVIEWS: "Reviews the mechanism and recommends changes"
+→ Reference the original founding decision in the fact text when possible
+
+Example:
+- Text: "Establishes the Santiago network for averting loss and damage"
+  → relation_type: ESTABLISHES (FOUNDING action)
+- Text: "Decides that the Santiago network shall have the following functions"
+  → relation_type: FURTHER_DEVELOPS (FOLLOW-UP action, not creation)
+- Text: "Also recalling decision 2/CMA.2"
+  → relation_type: REFERENCES (points backward to founding decision)
+
+This distinction is CRITICAL for answering questions like
+"Which decision first created X?" vs "Which decision expanded X?"
+
 ## EXTRACTION MANDATE:
 - Extract ALL explicit relationships, not just the primary one
 - If a decision discusses multiple topics, create multiple ADDRESSES / \

--- a/coded_tools/graph_rag/constrained_prompts.py
+++ b/coded_tools/graph_rag/constrained_prompts.py
@@ -1,0 +1,366 @@
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+"""
+Modified versions of Graphiti's entity and fact extraction prompts.
+"""
+from typing import Any
+
+from graphiti_core.prompts.models import Message
+
+
+def extract_text_constrained(context: dict[str, Any]) -> list[Message]:
+    """
+    Modified version of Graphiti's entity extraction prompt.
+    This prompt is designed to extract only entities explicitly mentioned
+    in the text.
+    """
+
+    sys_prompt = """
+You are an AI assistant that extracts entity nodes from climate conference
+documents. Your ONLY task is to extract entities that are EXPLICITLY MENTIONED
+in the provided text.
+
+CRITICAL RULES:
+1. DO NOT use your general knowledge about climate, politics, or world events.
+2. DO NOT infer entities that are not explicitly written in the text.
+3. ONLY extract entities that appear as specific words or phrases in the \
+document.
+4. If an entity is not mentioned by name in the text, DO NOT extract it.
+
+PROHIBITIONS (NEVER EXTRACT THESE):
+- "Conference of the Parties" or any variation (e.g., "Conference of the \
+Parties serving as the meeting of the Parties to the Paris Agreement or \
+Conference of the Parties serving as the meeting of the Parties to the Kyoto \
+Protocol") or "CP" or "CMP" or "CMA" when they refer to the body itself.
+- "Subsidiary Body for Implementation" or "SBI" when it refers to the body \
+itself.
+- "Subsidiary Body for Scientific and Technological Advice" or "SBSTA" when \
+it refers to the body itself.
+- Session numbers, meeting descriptors, or procedural language.
+- These are document metadata, NOT entities to extract.
+"""
+
+    user_prompt = f"""
+<ENTITY TYPES>
+{context['entity_types']}
+</ENTITY TYPES>
+
+<TEXT>
+{context['episode_content']}
+</TEXT>
+
+Given the above text, extract entities that are "EXPLICITLY MENTIONED" \
+in the TEXT. You must ONLY extract entities whose names appear as actual \
+words or phrases in the provided text.
+
+For each entity extracted, also determine its entity type based on the \
+provided ENTITY TYPES and their descriptions. Indicate the classified \
+entity type by providing its entity_type_id.
+
+{context['custom_prompt']}
+
+PURPOSE OF EXTRACTION:
+You are extracting entities for question-answering. When a user asks a \
+question, the graph will find relevant relationships, then use the \
+descriptions present in the entities/concepts to answer questions.
+
+CRITICAL: Extract GENEROUSLY. The more entities you extract, the easier \
+it is to map questions to the right information. It's better to extract \
+too many entities than to miss important concepts.
+
+WHAT TO EXTRACT (text explicitly mentioned in the documents):
+
+1. Structural References: Decision/Resolution IDs, Article numbers, \
+Annex references. Examples: "Decision 1/CP.21", "decision 1/CP.21" \
+(lowercase too), "Article 6", "Annex I".
+
+2. Named Entities: Specific agreements, organizations, funds, countries, \
+bodies, committees. Examples: "Paris Agreement", "Green Climate Fund", \
+"Morocco", "Standing Committee on Finance".
+
+3. ALL Important Concepts: Extract EVERY substantive topic, mechanism, or \
+term in the text:
+- All substantive topics and themes: Every topic the text discusses
+- All named entities: Every country, organization, agreement, mechanism, \
+fund, body, committee, people, groups and more.
+- All references: Every decision, article, annex, or document referenced
+- Climate topics: mitigation, adaptation, finance, transparency, technology, \
+capacity-building
+- Policy mechanisms and governance concepts: NDCs, NAPs, work programmes, \
+frameworks, guidelines, modalities
+- Sectors: energy, forestry, oceans, agriculture, water, transport, buildings
+- Groups: developing countries, vulnerable communities, country groups, \
+indigenous people, LDCs, SIDS, VNS, G77, G20, important people, etc.
+- Processes: reporting, review, stocktake, compliance, implementation, \
+monitoring, treaties, guidelines, methodologies, discussions
+- Financial: funds, mobilization, flows, support, resources, contributions
+- Technical: emissions, renewable energy, technology transfer, assessments
+- ANY concept, term, or topic that appears - if in doubt, please extract it!
+
+4. EXTRACTION STRATEGY - BE COMPREHENSIVE:
+- Extract both general concepts AND specific instances - e.g., extract \
+"climate finance" AND "Green Climate Fund" AND "financial resources"
+- Extract multi-word phrases when they form meaningful concepts - e.g., \
+"technology needs assessments", "capacity-building initiatives"
+- Extract both full names and common abbreviations if both appear - e.g., \
+"nationally determined contributions" AND "NDCs"
+
+5. GUIDELINES:
+- If someone could ask "What decisions relate to X?", extract X as an entity
+- Extract LIBERALLY and ABUNDANTLY - more entities = better retrieval = \
+better answers
+- Every paragraph should yield multiple entities
+- Aim for comprehensive coverage so no information is missed
+
+6. CRITICAL CONSTRAINTS:
+- DO NOT extract generic role titles, institutional references, or group \
+categories (e.g., "president", "government", "countries", "ministers", \
+"delegates") unless they include specific identifying context (e.g., \
+"President of France", "Government of Canada", "developing countries").
+- DO NOT extract implied entities based on the document topic.
+- DO NOT use your knowledge of climate politics to add entities.
+- If a country, person, or organization is mentioned, extract its EXACT \
+name from the text.
+- Avoid creating nodes for relationships or actions.
+- Avoid creating nodes for temporal information like dates, times or years \
+(these will be added to edges later)
+- Be as explicit as possible in your node names, using full names and \
+avoiding abbreviations
+
+7. ABSOLUTE PROHIBITIONS - DO NOT EXTRACT THESE AS ENTITIES:
+- "Conference of the Parties" (COP) - This is a procedural body name, NOT \
+an entity
+- "Conference of the Parties serving as the meeting of the Parties to the \
+Paris Agreement" (CMA) - This is just the full name of CMA, NOT an entity
+- "Conference of the Parties serving as the meeting of the Parties to the \
+Kyoto Protocol" (CMP) - This is just the full name of CMP, NOT an entity
+- "Subsidiary Body for Implementation" - This is a procedural body, NOT an \
+entity
+- "Subsidiary Body for Scientific and Technological Advice" - This is a \
+procedural body, NOT an entity
+- Document headers/metadata (session numbers, report numbers, dates)
+- Decision/Resolution IDs themselves (e.g., "Decision 15/CMA.1" is metadata, \
+not an entity)
+  * However, DO extract what the decision is ABOUT if explicitly stated
+- Annex headers (e.g., "Annex to Decision 15/CMA.1" is metadata)
+
+IF YOU SEE THESE PHRASES IN THE TEXT, SKIP THEM COMPLETELY. DO NOT CREATE \
+ENTITY NODES FOR THEM.
+
+GOAL: Create a DENSE entity graph where:
+1. Every important concept is captured as an entity.
+2. Questions can easily map to relevant concepts and comprehensively answer \
+all questions about the text independently.
+3. No information is lost due to missing entities.
+4. No entities are missed due to assumptions or omissions.
+5. No entities are created that are not explicitly mentioned in the text.
+
+CRITICAL: ANNEX CONTENT IS SEPARATE FROM DECISION CONTENT:
+If you are processing an annex episode (episode name contains "Annex to \
+Decision X"):
+- Extract entities from the annex content
+- These entities belong to the ANNEX, NOT to the parent decision
+- Do NOT create relationships between annex entities and the decision ID
+- The annex EXPLAINS / SUPPLEMENTS the decision, but its entities are separate
+Example: If "Financial Mechanism" appears in "Annex to Decision 15/CMA.1":
+  - Extract "Financial Mechanism" as an entity
+  - This entity appears in the ANNEX, not in the decision text itself
+  - The relationship is:
+  Financial Mechanism → mentioned in → ANNEX → connected to → Decision
+  - The entities are indirectly connected through the ANNEX
+  - CORRECT: "The ANNEX to Decision 15/CMA.1 mentions Financial Mechanism"
+  - INCORRECT: "Decision 15/CMA.1 mentions Financial Mechanism"
+"""
+    return [
+        Message(role="system", content=sys_prompt),
+        Message(role="user", content=user_prompt),
+    ]
+
+
+def extract_edges_constrained(context: dict[str, Any]) -> list[Message]:
+    """
+    Modified version of Graphiti's fact extraction prompt.
+    This prompt is designed to extract only relationships explicitly mentioned
+    in the text.
+    """
+    return [
+        Message(
+            role="system",
+            content=(
+                """
+You are an expert fact extractor that extracts fact triples ONLY from \
+explicitly stated relationships in text. You must ONLY extract relationships \
+that are directly stated in the text.
+DO NOT infer relationships from your general knowledge.
+DO NOT make assumptions about what entities might be related based on typical \
+patterns.
+1. Extracted fact triples should also be extracted with relevant date \
+information when explicitly provided.
+2. Treat CURRENT TIME as the time CURRENT MESSAGE was sent.
+All temporal information should be extracted relative to this time.
+"""
+            ),
+        ),
+        Message(
+            role="user",
+            content=f"""
+<FACT TYPES>
+{context['edge_types']}
+</FACT TYPES>
+
+<PREVIOUS_MESSAGES>
+{list(context['previous_episodes'])}
+</PREVIOUS_MESSAGES>
+
+<CURRENT_MESSAGE>
+{context['episode_content']}
+</CURRENT_MESSAGE>
+
+<ENTITIES>
+{context['nodes']}
+</ENTITIES>
+
+<REFERENCE_TIME>
+{context['reference_time']}  # ISO 8601 (UTC); used to resolve relative \
+time mentions
+</REFERENCE_TIME>
+
+# TASK
+Extract ONLY factual relationships between the given ENTITIES that are \
+EXPLICITLY STATED in the CURRENT MESSAGE.
+
+## CRITICAL CONSTRAINTS:
+- Only extract facts where the relationship is DIRECTLY STATED in the text.
+- DO NOT infer relationships from your general knowledge.
+- DO NOT assume connections because entities are typically related (e.g., \
+don't connect "climate decision" to "president" just because presidents are \
+involved in climate policy).
+- Only extract facts that:
+  * involve two DISTINCT ENTITIES from the ENTITIES list,
+  * are EXPLICITLY STATED in the CURRENT MESSAGE (not implied, not inferred),
+  * can be represented as edges in a knowledge graph.
+- Facts should include entity names rather than pronouns whenever possible.
+- The FACT TYPES provide a list of the most important types of facts, make \
+sure to extract facts of these types.
+- The FACT TYPES are not an exhaustive list, extract all facts from message \
+even if they do not fit into one of the FACT TYPES.
+- The FACT TYPES each contain their fact_type_signature which represents \
+the source and target entity types.
+
+You may use information from the PREVIOUS MESSAGES only to disambiguate \
+references or support continuity.
+
+{context['custom_prompt']}
+
+## EXTRACTION RULES
+
+1. Entity ID Validation: `source_entity_id` and `target_entity_id` must use \
+only the `id` values from the ENTITIES list provided above.
+   - CRITICAL: Using IDs not in the list will cause the edge to be rejected.
+2. Each fact must involve two distinct entities.
+3. Use a SCREAMING_SNAKE_CASE string as the `relation_type` (e.g., \
+REFERENCES, CITES, SUPPLEMENTS, HAS_ANNEX).
+4. Do not emit duplicate or semantically redundant facts.
+5. The `fact` should closely paraphrase the original source sentence(s).
+Do not verbatim quote the original text.
+6. Use `REFERENCE_TIME` to resolve vague or relative temporal expressions \
+(e.g., "last week").
+7. Do **not** hallucinate or infer temporal bounds from unrelated events.
+
+## RELATIONSHIP TYPES FOR CLIMATE DOCUMENTS
+
+### PURPOSE: Extract relationships that connect concepts to enable Q&A.
+When a user asks "What decisions relate to climate finance?", the graph
+should show which decisions explicitly mention/address/establish/relate \
+to climate finance.
+
+### CRITICAL: Extract MANY relationships. Every connection between entities \
+should captured. Dense relationship mapping ensures comprehensive information \
+retrieval.
+
+Common explicit relationships to extract (when stated in text):
+
+1. Structural Relationships:
+  - Decision A REFERENCES Decision B (e.g., "Recalling decision 1/CP.21")
+  - Decision A CITES Article X (e.g., "pursuant to Article 6")
+  - Annex SUPPLEMENTS Decision (structural relationship)
+  - Decision ADOPTS framework/guidance/mechanism
+
+2. Topical Relationships (extract when explicitly stated):
+  - Decision ADDRESSES concept (e.g., "decision on climate finance addresses \
+mobilization")
+  - Decision ESTABLISHES mechanism (e.g., "establishes the transparency \
+  framework")
+  - Decision RELATES_TO topic (when text explicitly discusses the topic)
+  - Article DEFINES concept (e.g., "Article 6 defines cooperative approaches")
+  - Decision INVITES/REQUESTS/URGES body (when explicitly stated)
+
+3. Financial & Support Relationships:
+  - Fund PROVIDES_SUPPORT_FOR concept (e.g., "Adaptation Fund provides \
+support for adaptation")
+  - Decision ESTABLISHES_FUND fund_name
+  - Country/Group RECEIVES_SUPPORT (when explicitly mentioned)
+
+4. Governance Relationships:
+  - Body CONDUCTS process (e.g., "Standing Committee on Finance conducts \
+review")
+  - Decision MANDATES work_programme
+  - Body REPORTS_TO parent_body
+
+### EXAMPLES (EXTRACT RELATIONSHIPS COMPREHENSIVELY):
+1. "Decision 15/CMA.1 addresses climate finance and technology transfer"
+Extract ALL relationships:
+- Decision 15/CMA.1 ADDRESSES climate finance
+- Decision 15/CMA.1 ADDRESSES technology transfer
+
+2. "The Standing Committee on Finance will review financial flows from \
+developed to developing countries"
+Extract ALL relationships:
+- Standing Committee on Finance CONDUCTS review
+- Standing Committee on Finance REVIEWS financial flows
+- financial flows FLOW_FROM developed countries
+- financial flows FLOW_TO developing countries
+
+3. "Decision 1/CP.21 requests the IPCC to provide special reports on 1.5°C"
+Extract ALL relationships:
+- Decision 1/CP.21 REQUESTS IPCC
+- IPCC PROVIDES special reports
+- special reports RELATES_TO 1.5°C goal
+
+## EXTRACTION MANDATE:
+- Extract ALL explicit relationships, not just the primary one
+- If a decision discusses multiple topics, create multiple ADDRESSES / \
+RELATES_TO edges
+- If text mentions actions, create edges for those actions
+- Extract liberally - dense relationships = better question answering
+
+## CRITICAL: KEEP ANNEX ENTITIES SEPARATE FROM DECISION ENTITIES:
+- If processing "Annex to Decision X/Y.Z" episode:
+  * Entities mentioned in the annex belong to the ANNEX episode
+  * Do NOT create edges like "Decision X/Y.Z MENTIONS entity" for entities \
+only in the annex
+  * Only the annex episode itself relates to the decision (structural \
+relationship)
+- Example: "Financial Mechanism" in "Annex to Decision 15/CMA.1"
+  * CORRECT: Extract "Financial Mechanism" entity (belongs to annex episode)
+  * WRONG: Create edge "Decision 15/CMA.1 MENTIONS Financial Mechanism"
+
+## DATETIME RULES
+- Use ISO 8601 with "Z" suffix (UTC) (e.g., 2025-04-30T00:00:00Z)
+- If the fact is ongoing (present tense), set `valid_at` to REFERENCE_TIME
+- If a change/termination is expressed, set `invalid_at` to the relevant \
+timestamp
+- Leave both fields `null` if no explicit or resolvable time is stated
+- If only a date is mentioned (no time), assume 00:00:00
+- If only a year is mentioned, use January 1st at 00:00:00
+        """,
+        ),
+    ]

--- a/coded_tools/graph_rag/falkordb_ingestion.py
+++ b/coded_tools/graph_rag/falkordb_ingestion.py
@@ -1,0 +1,1790 @@
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+# pylint: disable=too-many-lines,wrong-import-position
+"""
+UNFCCC Climate Document Ingestion for FalkorDB Knowledge Graph.
+
+This module ingests United Nations Framework Convention on Climate Change (UNFCCC)
+documents into a FalkorDB-backed knowledge graph using the Graphiti framework.
+
+Key Features:
+    - Parses UNFCCC COP, CMA, CMP, SBI, and SBSTA decision documents
+    - Extracts structured information: decisions, resolutions, annexes, and paragraphs
+    - Identifies and extracts cross-document references between decisions
+    - Supports incremental processing with checkpoint-based resume functionality
+    - Includes performance optimizations for large-scale graph operations
+
+Document Structure:
+    - Splits documents by decisions/resolutions as primary sections
+    - Separates annexes into distinct episodes
+    - Extracts numbered paragraphs for granular reference access
+    - Preserves metadata: conference type, year, session, location, FCCC references
+
+Reference Extraction:
+    - Decision references (e.g., "decision 1/CP.21, paragraph 69")
+    - Article references (e.g., "Article 6 of the Paris Agreement")
+    - Annex references (e.g., "Annex I to decision 4/CMA.1")
+    - Paragraph references with optional decision context
+
+Note:
+    Reference linking, annex linking, and conference linking features have been
+    disabled to reduce episode count and improve processing performance. References
+    are still extracted and stored in episode metadata for potential future use.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from collections import defaultdict
+from datetime import datetime
+from datetime import timezone
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from neuro_san.interfaces.coded_tool import CodedTool
+
+from dotenv import load_dotenv
+
+# Load environment variables before importing graphiti modules.
+# The graphiti_core.embedder.client reads EMBEDDING_DIM at import time.
+_current_dir = Path(__file__).parent
+load_dotenv(dotenv_path=_current_dir / ".env")
+
+# Monkey patch FalkorDB search functions to prevent query timeout issues.
+import graphiti_core.search.search_filters as search_filters_module
+import graphiti_core.search.search_utils as search_utils_module
+from graphiti_core import Graphiti
+from graphiti_core.driver.driver import GraphDriver
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.falkordb_driver import FalkorDriver
+from graphiti_core.edges import EntityEdge
+from graphiti_core.nodes import EpisodeType
+from graphiti_core.search.search_config_recipes import NODE_HYBRID_SEARCH_RRF
+
+_original_edge_search_filter = (
+    search_filters_module.edge_search_filter_query_constructor
+)
+_original_edge_fulltext_search = search_utils_module.edge_fulltext_search
+
+
+def patched_edge_search_filter_query_constructor(
+    filters, provider: GraphProvider
+) -> tuple[list[str], dict[str, Any]]:
+    """Prevents FalkorDB query timeouts by normalizing empty edge UUID lists.
+
+    Converts empty edge_uuids lists to None to avoid inefficient query patterns
+    that cause timeouts in FalkorDB when filtering with empty collections.
+
+    Args:
+        filters: Search filter object potentially containing edge_uuids list.
+        provider: Graph database provider instance.
+
+    Returns:
+        Tuple of query parts and parameters for edge search filtering.
+    """
+    if (
+        hasattr(filters, "edge_uuids")
+        and filters.edge_uuids is not None
+        and len(filters.edge_uuids) == 0
+    ):
+        filters.edge_uuids = None
+    return _original_edge_search_filter(filters, provider)
+
+
+async def patched_edge_fulltext_search(
+    driver: GraphDriver,
+    query: str,
+    search_filter,
+    group_ids: list[str] | None = None,
+    limit: int = 10,
+) -> list[EntityEdge]:
+    """Optimizes edge search performance by using direct lookups instead of full-text search.
+
+    For large knowledge graphs, full-text search becomes prohibitively slow. This
+    patched version uses direct UUID-based lookups when edge_uuids are provided,
+    falling back to empty results for unrestricted searches to maintain performance.
+
+    Args:
+        driver: Graph database driver instance.
+        query: Search query string (used only in fallback).
+        search_filter: Filter object with optional edge_uuids constraint.
+        group_ids: Optional list of group IDs to filter results.
+        limit: Maximum number of results to return.
+
+    Returns:
+        List of EntityEdge objects matching the search criteria.
+    """
+
+    # Treat empty edge_uuids list as None
+    if (
+        hasattr(search_filter, "edge_uuids")
+        and search_filter.edge_uuids is not None
+        and len(search_filter.edge_uuids) == 0
+    ):
+        search_filter.edge_uuids = None
+
+    # For large graphs, full-text search is too slow. If no specific edge_uuids
+    # are provided, skip full-text search and rely on vector similarity instead.
+    if not hasattr(search_filter, "edge_uuids") or search_filter.edge_uuids is None:
+        return []
+
+    # For small UUID lists, direct lookup is much faster than full-text search
+    if (
+        hasattr(search_filter, "edge_uuids")
+        and search_filter.edge_uuids is not None
+        and len(search_filter.edge_uuids) > 0
+        and len(search_filter.edge_uuids) <= 20
+    ):
+        match_query = """
+        MATCH (n:Entity)-[e:RELATES_TO]->(m:Entity)
+        WHERE e.uuid IN $edge_uuids
+        """
+        if group_ids is not None:
+            match_query += " AND e.group_id IN $group_ids"
+
+        match_query += """
+        RETURN
+            e.uuid AS uuid,
+            n.uuid AS source_node_uuid,
+            m.uuid AS target_node_uuid,
+            e.group_id AS group_id,
+            e.created_at AS created_at,
+            e.name AS name,
+            e.fact AS fact,
+            e.episodes AS episodes,
+            e.expired_at AS expired_at,
+            e.valid_at AS valid_at,
+            e.invalid_at AS invalid_at,
+            properties(e) AS attributes
+        LIMIT $limit
+        """
+
+        try:
+            records, _, _ = await driver.execute_query(
+                match_query,
+                edge_uuids=search_filter.edge_uuids,
+                group_ids=group_ids if group_ids else [],
+                limit=limit,
+                routing_="r",
+            )
+
+            from graphiti_core.search.search_utils import \
+                get_entity_edge_from_record  # pylint: disable=import-outside-toplevel
+
+            edges = [
+                get_entity_edge_from_record(record, driver.provider)
+                for record in records
+            ]
+            return edges
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Fallback to original full-text search if direct lookup fails
+            pass
+
+    # Fallback to original implementation for other cases
+    return await _original_edge_fulltext_search(
+        driver, query, search_filter, group_ids, limit
+    )
+
+
+search_filters_module.edge_search_filter_query_constructor = (
+    patched_edge_search_filter_query_constructor
+)
+search_utils_module.edge_fulltext_search = patched_edge_fulltext_search
+
+# Patch FalkorDriver.execute_query to sanitize empty edge_uuids at the driver level.
+_original_falkor_execute_query = FalkorDriver.execute_query
+
+
+async def patched_falkor_execute_query(self, cypher_query_, **kwargs):
+    """Sanitizes query parameters to prevent FalkorDB execution errors.
+
+    Removes empty edge_uuids parameters and adjusts Cypher query syntax accordingly
+    to avoid malformed queries that would cause database errors or timeouts.
+
+    Args:
+        self: FalkorDriver instance.
+        cypher_query_: The Cypher query string to execute.
+        **kwargs: Query parameters including potential edge_uuids list.
+
+    Returns:
+        Query execution result from the original FalkorDB driver method.
+    """
+    if (
+        "edge_uuids" in kwargs
+        and isinstance(kwargs["edge_uuids"], list)
+        and len(kwargs["edge_uuids"]) == 0
+    ):
+        kwargs.pop("edge_uuids", None)
+        if "WHERE e.uuid in $edge_uuids" in cypher_query_:
+            cypher_query_ = cypher_query_.replace(
+                " WHERE e.uuid in $edge_uuids AND ", " WHERE "
+            )
+            cypher_query_ = cypher_query_.replace(" AND e.uuid in $edge_uuids", "")
+            cypher_query_ = cypher_query_.replace(" WHERE e.uuid in $edge_uuids", "")
+    return await _original_falkor_execute_query(self, cypher_query_, **kwargs)
+
+
+FalkorDriver.execute_query = patched_falkor_execute_query
+
+
+class FalkorDBIngestionEnhanced(CodedTool):  # pylint: disable=too-many-instance-attributes
+    """Ingests UNFCCC climate documents into FalkorDB knowledge graph.
+
+    This class processes United Nations Framework Convention on Climate Change (UNFCCC)
+    documents, extracting structured information about decisions, resolutions, annexes,
+    and cross-document references. Creates a queryable knowledge graph enabling semantic
+    search, temporal analysis, and citation resolution across climate conference proceedings.
+
+    Features:
+        - Document parsing for COP, CMA, CMP, SBI, and SBSTA sessions
+        - Decision and resolution extraction with metadata
+        - Cross-document reference detection (stored in metadata)
+        - Annex identification and separation into distinct episodes
+        - Paragraph-level indexing for granular access
+        - Checkpoint-based resume capability for interrupted ingestion
+        - Performance optimizations for large-scale graph operations
+
+    Note:
+        Reference linking, annex linking, and conference hierarchy features are currently
+        disabled to optimize processing performance and reduce episode count.
+    """
+
+    # Configure console-only logging
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(message)s",
+        handlers=[logging.StreamHandler()]
+    )
+
+    CONFERENCE_NAMES = {
+        "CMA": (
+            "Conference of the Parties serving as the meeting of the Parties "
+            "to the Paris Agreement"
+        ),
+        "CMP": (
+            "Conference of the Parties serving as the meeting of the Parties "
+            "to the Kyoto Protocol"
+        ),
+        "COP": "Conference of the Parties",
+        "SBI": "Subsidiary Body for Implementation",
+        "SBSTA": "Subsidiary Body for Scientific and Technological Advice",
+    }
+
+    FRONT_MATTER_MARKERS = [
+        "Contents",
+        "Decisions adopted by the Conference",
+        "Conference of the Parties serving as the meeting",
+        "Addendum",
+        "Part two:",
+    ]
+
+    FALLBACK_CHARS = 6000
+    INCLUDE_HEADING_IN_BODY = True
+    MAX_EPISODE_NAME_LEN = 250
+    MIN_SECTION_LEN = 400
+    PROCESS_SUBDIRECTORIES = True
+
+    # Regex patterns for document parsing
+    YEAR_RE = re.compile(r"(20\d{2})")
+    CONFERENCE_TYPE_RE = re.compile(
+        r"(?P<type>CMA|CMP|COP|SBI|SBSTA)(?P<year>\d{4})_(?P<session>\d+)",
+        re.IGNORECASE,
+    )
+    # Combined pattern for both Decisions and Resolutions
+    DECISION_RESOLUTION_HEADING_RE = re.compile(
+        r"(?m)^(?P<h>(?:Decision|Resolution)\s+(?:No\.?\s*)?[\dIVXLC]+(?:\s*/\s*[A-Za-z]+\.\d+|"
+        r"(?:\s*/\s*[A-Za-z]+(?:\.\d+)?))?[^\n]*)$"
+    )
+    OTHER_HEADING_RE = re.compile(
+        r"(?mi)^(?P<h>(Chapter|Section|Agenda item|Article|Part)\s+[^\n]+)$",
+        re.IGNORECASE,
+    )
+    # Annex pattern for metadata extraction only (not for primary splitting)
+    ANNEX_HEADING_RE = re.compile(
+        r"(?mi)^(?P<h>Annex(?:\s+[IVXLC]+|\s+\d+)?[^\n]*)$", re.IGNORECASE
+    )
+    LOCATION_DATE_RE = re.compile(
+        r"held in (?P<location>[^,\n]+?)(?:\s+from\s+(?P<date>[^\n]+?))?(?:\n|$)",
+        re.IGNORECASE,
+    )
+    FCCC_DOC_RE = re.compile(r"(?P<fccc>FCCC/[A-Z/]+/\d{4}/[\d/A-Za-z\.]+)")
+
+    # Reference extraction patterns
+    # Matches decision/resolution references with optional paragraph numbers
+    DECISION_REFERENCE_RE = re.compile(
+        r"(?i)(?:decision|resolution)s?\s+(?:No\.?\s*)?"
+        r"(?P<number>[\dIVXLC]+(?:\s*/\s*[A-Za-z]+\.\d+))"
+        r"(?:,\s*paragraph(?:s)?\s+(?P<paragraphs>[\d\-,\s]+))?"
+    )
+
+    # Matches article references with optional paragraphs and agreements
+    ARTICLE_REFERENCE_RE = re.compile(
+        r"(?i)Article\s+(?P<number>[\dIVXLC]+)"
+        r"(?:,\s*paragraph(?:s)?\s+(?P<paragraphs>[\d\-,\s]+))?"
+        r"(?:\s+of\s+the\s+(?P<agreement>[^\n,;\.]+))?"
+    )
+
+    # Matches standalone paragraph references
+    PARAGRAPH_REFERENCE_RE = re.compile(
+        r"(?i)paragraphs?\s+(?P<paragraphs>[\d\-–,\s]+)"
+        r"(?:\s+of\s+(?:decision|resolution)\s+(?P<number>[\dIVXLC]+(?:\s*/\s*[A-Za-z]+\.\d+)))?"
+    )
+
+    # Matches annex references with optional decision context
+    ANNEX_REFERENCE_RE = re.compile(
+        r"(?i)(?:the\s+)?annex(?:\s+(?P<annex_id>[IVXLC]+|\d+))?"
+        r"(?:\s+to\s+(?:decision|resolution)\s+(?P<decision_number>[\dIVXLC]+"
+        r"(?:\s*/\s*[A-Za-z]+\.\d+)))?"
+    )
+
+    CLIMATE_QUERIES = [
+        "What is the Paris Agreement?",
+        "What are the decisions on climate finance?",
+        "What is the global goal on adaptation?",
+        "What are the mechanisms for Article 6?",
+        "What is the new collective quantified goal on climate finance?",
+    ]
+
+    NODE_QUERIES = [
+        "climate finance",
+        "adaptation",
+        "mitigation",
+        "Paris Agreement",
+        "developed country Parties",
+    ]
+
+    def __init__(self) -> None:
+        """Initializes the FalkorDB ingestion tool with default configuration.
+
+        Sets up logging, loads configuration from environment variables, and
+        initializes data structures for tracking decisions and references during ingestion.
+        """
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.config: Dict[str, Any] = self._load_config()
+        # Maps decision IDs to episode names (only actual decisions, not references)
+        self.decision_registry: Dict[str, str] = {}
+        # Tracks all references found during parsing
+        self.reference_map: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+
+    async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> str:
+        """Entry point for Neuro-San CodedTool interface.
+
+        Accepts configuration overrides via args parameter and executes the full
+        ingestion pipeline, returning a summary of processing results.
+
+        Args:
+            args: Optional configuration overrides (data_dir, batch_size, etc.).
+            sly_data: Neuro-San system data (unused in this implementation).
+
+        Returns:
+            Summary string with counts of episodes processed, references extracted,
+            and relationships created.
+        """
+        del sly_data  # unused in this tool
+        args = args or {}
+        if args:
+            self.config = self._load_config(args)
+        summary = await self.run()
+        return (
+            "FalkorDB ingestion completed: "
+            f"{summary['success']} succeeded, {summary['failed']} failed "
+            f"out of {summary['prepared']} prepared episodes. "
+            f"{summary['references_extracted']} references extracted and stored in metadata."
+        )
+
+    async def run(self) -> Dict[str, int]:
+        """Executes complete document ingestion pipeline.
+
+        Connects to FalkorDB, processes all documents in the configured data directory,
+        extracts structured information and references, optionally runs demonstration
+        queries, and returns processing statistics.
+
+        Returns:
+            Dictionary with processing statistics:
+                - prepared: Total episodes created from documents
+                - success: Episodes successfully added to graph
+                - failed: Episodes that failed to process
+                - references_extracted: Total cross-document references found
+        """
+        self.logger.info(
+            "Connecting to FalkorDB database at %s:%s",
+            self.config["host"],
+            self.config["port"],
+        )
+        graphiti = self._create_graphiti_client()
+        self.logger.info("Successfully connected to FalkorDB")
+
+        summary: Dict[str, int] = {
+            "prepared": 0,
+            "success": 0,
+            "failed": 0,
+            "references_extracted": 0,
+        }
+        success_count = 0
+        failed: List[Tuple[str, str]] = []
+
+        try:
+            episodes = self.build_episodes(self.config["data_dir"])
+            episodes = self._limit_episodes(episodes)
+            self._log_episode_stats(episodes)
+
+            success_count, failed = await self._add_episodes(graphiti, episodes)
+
+            # Extract and count references
+            total_refs = sum(len(refs) for refs in self.reference_map.values())
+            summary["references_extracted"] = total_refs
+            self.logger.info(
+                "Extracted %d references from %d episodes",
+                total_refs,
+                len(self.reference_map),
+            )
+
+            # Reference linking, annex linking, and conference linking removed to reduce
+            # episode count and improve processing performance
+
+            if self.config["enable_demo_searches"] and success_count > 0:
+                await self._run_demo_searches(graphiti)
+            else:
+                self._log_demo_skipped_reason(success_count)
+
+            summary["prepared"] = len(episodes)
+            summary["success"] = success_count
+            summary["failed"] = len(failed)
+
+            if summary["failed"] > 0:
+                self.logger.warning("Failed episodes (first 10 shown):")
+                for name, error in failed[:10]:
+                    self.logger.warning("  - %s: %s", name[:100], error[:200])
+        finally:
+            await graphiti.close()
+            self.logger.info("\nConnection closed")
+
+        return summary
+
+    def build_episodes(  # pylint: disable=too-many-statements,too-many-locals,too-many-branches
+        self, dir_path: Path
+    ) -> List[Dict[str, Any]]:
+        """Converts source documents into structured episodes with metadata and references.
+
+        Processes all text files in the specified directory, splitting them into
+        decision/resolution sections, extracting metadata, identifying cross-document
+        references, and building paragraph indices for granular access.
+
+        Args:
+            dir_path: Path to directory containing UNFCCC document text files.
+
+        Returns:
+            List of episode dictionaries, each containing:
+                - name: Unique episode identifier
+                - episode_body: Formatted text with metadata headers
+                - source_description: Human-readable source description
+                - reference_time: Datetime for temporal indexing
+                - metadata: Extracted metadata (conference type, year, location, etc.)
+                - decision_id: Decision/resolution identifier if applicable
+                - annex_id: Annex identifier if applicable
+                - references: List of cross-document references found
+                - document_name: Source filename stem
+
+        Raises:
+            FileNotFoundError: If dir_path does not exist.
+            NotADirectoryError: If dir_path is not a directory.
+        """
+        if not dir_path.exists():
+            raise FileNotFoundError(f"DATA_DIR does not exist: {dir_path}")
+        if not dir_path.is_dir():
+            raise NotADirectoryError(f"DATA_DIR is not a directory: {dir_path}")
+
+        documents = self._collect_documents(dir_path)
+        episodes: List[Dict[str, Any]] = []
+
+        if not documents:
+            self.logger.warning("No .txt files found in %s", dir_path)
+            return episodes
+
+        self.logger.info("Found %d document files to process", len(documents))
+
+        for path in documents:
+            text = self._read_text(path)
+            if not text:
+                continue
+
+            year = self._extract_year_from_filename(path)
+            reference_time = datetime(year, 1, 1, tzinfo=timezone.utc)
+
+            file_metadata = self._extract_metadata_from_filename(path)
+            doc_metadata = self._extract_document_metadata(text)
+            combined_metadata = {**file_metadata, **doc_metadata}
+
+            sections = self._split_document(text)
+            if not sections:
+                self.logger.warning("No sections extracted from %s", path.name)
+                continue
+
+            self.logger.info("Processing %s: %d sections", path.name, len(sections))
+            source_description = self._build_source_description(
+                path, file_metadata, year
+            )
+
+            for idx, section in enumerate(sections, 1):
+                decision_id = self._extract_decision_id(section.get("title", ""))
+                annex_id = self._extract_annex_id(section.get("title", ""))
+
+                episode_name = f"{path.stem}::{section.get('title') or f'Part {idx}'}"
+                body = self._build_episode_body(section["body"], combined_metadata)
+
+                references = self._extract_references(section["body"], decision_id)
+                paragraph_index = self._extract_paragraph_index(section["body"])
+
+                # Store in combined metadata
+                enriched_metadata = combined_metadata.copy()
+                if decision_id:
+                    enriched_metadata["decision_id"] = decision_id
+                    self.decision_registry[decision_id] = episode_name
+
+                if annex_id:
+                    enriched_metadata["annex_id"] = annex_id
+
+                if references:
+                    enriched_metadata["references"] = references
+                    self.reference_map[episode_name] = references
+
+                if paragraph_index:
+                    enriched_metadata["paragraph_index"] = paragraph_index
+                    if self.config["verbose_logging"]:
+                        self.logger.debug(
+                            "Extracted %d paragraphs from %s",
+                            len(paragraph_index),
+                            episode_name[:50],
+                        )
+
+                episodes.append(
+                    {
+                        "name": episode_name[: self.MAX_EPISODE_NAME_LEN],
+                        "episode_body": body,
+                        "source_description": source_description,
+                        "reference_time": reference_time,
+                        "metadata": enriched_metadata,
+                        "decision_id": decision_id,
+                        "annex_id": annex_id,
+                        "references": references,
+                        "document_name": path.stem,
+                    }
+                )
+                if self.config["verbose_logging"]:
+                    self.logger.info("Prepared episode: %s", episode_name[:100])
+                    if decision_id:
+                        self.logger.info("  Decision ID: %s", decision_id)
+                    if annex_id:
+                        self.logger.info("  Annex ID: %s", annex_id)
+                    if references:
+                        self.logger.info("  Found %d references", len(references))
+
+        return episodes
+
+    def _extract_decision_id(self, title: str) -> Optional[str]:
+        """Extracts normalized decision or resolution identifier from section title.
+
+        Parses decision/resolution references (e.g., 'Decision 1/CP.21', 'Resolution 5/CMA.3')
+        and returns a normalized identifier. Excludes annex sections which are handled separately.
+
+        Args:
+            title: Section heading text to parse.
+
+        Returns:
+            Normalized decision/resolution ID (e.g., '1/CP.21'), or None if not a
+            decision/resolution.
+        """
+        if not title:
+            return None
+
+        if re.match(r"(?i)^\s*Annex", title):
+            return None
+
+        # Match only decisions and resolutions
+        match = re.search(
+            r"(?i)(?:Decision|Resolution)\s+(?:No\.?\s*)?([\dIVXLC]+(?:\s*/\s*[A-Za-z]+\.\d+))",
+            title,
+        )
+        if match:
+            return match.group(1).strip()
+        return None
+
+    def _extract_annex_id(self, title: str) -> Optional[str]:
+        """Extracts annex identifier from section title.
+
+        Detects annex sections and extracts their Roman numeral or Arabic number identifiers.
+        Unlabeled annexes are marked as 'unnumbered'.
+
+        Args:
+            title: Section heading text to parse.
+
+        Returns:
+            Annex identifier ('I', 'II', '1', '2', 'unnumbered'), or None if not an annex.
+        """
+        if not title:
+            return None
+
+        # Match annex headings
+        match = re.match(r"(?i)^\s*Annex(?:\s+([IVXLC]+|\d+))?", title)
+        if match:
+            annex_id = match.group(1)
+            return annex_id.strip() if annex_id else "unnumbered"
+        return None
+
+    def _extract_references(
+        self, text: str, source_decision_id: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """Extracts all cross-document references from text.
+
+        Identifies and extracts references to other decisions, resolutions, articles,
+        paragraphs, and annexes using regex patterns. Captures context around each
+        reference for semantic understanding.
+
+        Args:
+            text: Text to search for references.
+            source_decision_id: Optional decision ID of the source document for tracking.
+
+        Returns:
+            List of reference dictionaries, each containing:
+                - type: Reference type ('decision', 'article', 'paragraph', 'annex')
+                - target: Referenced decision/article identifier
+                - paragraphs: Referenced paragraph numbers if specified
+                - raw_text: Original matched text
+                - context: Surrounding text context
+                - source_decision: Source decision ID if provided
+        """
+        references: List[Dict[str, Any]] = []
+
+        # Extract decision/resolution references
+        for match in self.DECISION_REFERENCE_RE.finditer(text):
+            ref = {
+                "type": "decision",
+                "target": match.group("number").strip(),
+                "paragraphs": (
+                    match.group("paragraphs").strip()
+                    if match.group("paragraphs")
+                    else None
+                ),
+                "raw_text": match.group(0),
+                "context": self._extract_context(text, match.start(), match.end()),
+            }
+            references.append(ref)
+
+        # Extract article references
+        for match in self.ARTICLE_REFERENCE_RE.finditer(text):
+            ref = {
+                "type": "article",
+                "target": match.group("number").strip(),
+                "paragraphs": (
+                    match.group("paragraphs").strip()
+                    if match.group("paragraphs")
+                    else None
+                ),
+                "agreement": (
+                    match.group("agreement").strip()
+                    if match.group("agreement")
+                    else None
+                ),
+                "raw_text": match.group(0),
+                "context": self._extract_context(text, match.start(), match.end()),
+            }
+            references.append(ref)
+
+        # Extract annex references
+        for match in self.ANNEX_REFERENCE_RE.finditer(text):
+            annex_id = match.group("annex_id")
+            decision_number = match.group("decision_number")
+
+            ref = {
+                "type": "annex",
+                "annex_id": annex_id.strip() if annex_id else None,
+                "target": (
+                    decision_number.strip() if decision_number else None
+                ),
+                "raw_text": match.group(0),
+                "context": self._extract_context(text, match.start(), match.end()),
+            }
+            references.append(ref)
+
+        for match in self.PARAGRAPH_REFERENCE_RE.finditer(text):
+            if match.group("number"):
+                continue
+
+            ref = {
+                "type": "paragraph",
+                "paragraphs": match.group("paragraphs").strip(),
+                "raw_text": match.group(0),
+                "context": self._extract_context(text, match.start(), match.end()),
+            }
+            references.append(ref)
+
+        for ref in references:
+            ref["source_decision"] = source_decision_id
+
+        return references
+
+    def _extract_context(
+        self, text: str, start: int, end: int, window: int = 100
+    ) -> str:
+        """Extracts surrounding context for a reference match.
+
+        Captures text before and after the matched reference to provide semantic context,
+        useful for understanding how the reference is being used.
+
+        Args:
+            text: Full text containing the reference.
+            start: Start index of the reference match.
+            end: End index of the reference match.
+            window: Number of characters to include before and after (default: 100).
+
+        Returns:
+            Context string with ellipsis markers if truncated.
+        """
+        context_start = max(0, start - window)
+        context_end = min(len(text), end + window)
+        context = text[context_start:context_end]
+        context = " ".join(context.split())
+        if context_start > 0:
+            context = "..." + context
+        if context_end < len(text):
+            context = context + "..."
+        return context
+
+    def _extract_paragraph_index(self, text: str) -> Dict[str, str]:
+        """Extracts numbered paragraphs for granular citation resolution.
+
+        Builds an index mapping paragraph numbers to their text content, enabling
+        direct access to specific paragraphs (e.g., 'paragraph 69 of decision 1/CP.21')
+        without searching the full document.
+
+        Args:
+            text: Decision or resolution text containing numbered paragraphs.
+
+        Returns:
+            Dictionary mapping paragraph numbers (strings) to paragraph text (truncated
+            to 1000 chars).
+        """
+        paragraphs: Dict[str, str] = {}
+
+        # Standard numbered paragraphs (e.g., "1.", "67.")
+        numbered_pattern = r"^\s*(\d+)\.\s+(.+?)(?=^\s*\d+\.\s|\Z)"
+        matches = re.finditer(numbered_pattern, text, re.MULTILINE | re.DOTALL)
+
+        for match in matches:
+            para_num = match.group(1).strip()
+            para_text = match.group(2).strip()
+            para_text = " ".join(para_text.split())
+            paragraphs[para_num] = para_text[:1000]
+
+        # If no numbered paragraphs found, try Roman numerals (e.g., "I.", "IV.")
+        if not paragraphs:
+            roman_pattern = r"^\s*([IVXLC]+)\.\s+(.+?)(?=^\s*[IVXLC]+\.\s|\Z)"
+            matches = re.finditer(roman_pattern, text, re.MULTILINE | re.DOTALL)
+
+            for match in matches:
+                para_num = match.group(1).strip()
+                para_text = match.group(2).strip()
+                para_text = " ".join(para_text.split())
+                paragraphs[para_num] = para_text[:1000]
+
+        return paragraphs
+
+    def _load_config(
+        self, overrides: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Loads configuration from environment variables with optional overrides.
+
+        Reads connection settings, processing parameters, and feature flags from
+        environment variables. Accepts runtime overrides for flexible configuration.
+
+        Args:
+            overrides: Optional dictionary of configuration overrides.
+
+        Returns:
+            Complete configuration dictionary with keys:
+                - host, port, username, password: Database connection settings
+                - data_dir: Path to source documents
+                - batch_size, max_episodes, search_limit: Processing parameters
+                - enable_demo_searches, verbose_logging: Feature flags
+        """
+        overrides = overrides or {}
+
+        config: Dict[str, Any] = {
+            # Connection settings from environment only (no overrides allowed)
+            "host": os.environ.get("FALKORDB_HOST", "localhost"),
+            "port": os.environ.get("FALKORDB_PORT", "6379"),
+            "username": os.environ.get("FALKORDB_USERNAME"),
+            "password": os.environ.get("FALKORDB_PASSWORD"),
+            # Data source (overrideable)
+            "data_dir": Path(os.environ.get("DATA_DIR", "documents")),
+            # Processing settings (overrideable)
+            "batch_size": int(os.environ.get("BATCH_SIZE", "10")),
+            "max_episodes": int(os.environ.get("MAX_EPISODES", "0")),
+            "search_limit": int(os.environ.get("SEARCH_LIMIT", "5")),
+            # Feature toggles (overrideable)
+            "enable_demo_searches": os.environ.get(
+                "ENABLE_DEMO_SEARCHES", "true"
+            ).lower()
+            == "true",
+            "verbose_logging": os.environ.get("VERBOSE_LOGGING", "false").lower()
+            == "true",
+        }
+
+        if "data_dir" in overrides and overrides["data_dir"]:
+            config["data_dir"] = Path(str(overrides["data_dir"]))
+
+        int_keys = ("batch_size", "max_episodes", "search_limit")
+        for key in int_keys:
+            if key in overrides and overrides[key] is not None:
+                config[key] = int(overrides[key])
+
+        bool_keys = ("enable_demo_searches", "verbose_logging")
+        for key in bool_keys:
+            if key in overrides and overrides[key] is not None:
+                config[key] = self._to_bool(overrides[key])
+
+        return config
+
+    @staticmethod
+    def _to_bool(value: Any) -> bool:
+        """Converts various value types to boolean.
+
+        Handles string representations of booleans (e.g., "true", "1", "yes")
+        in addition to native boolean and other types.
+
+        Args:
+            value: Value to convert to boolean.
+
+        Returns:
+            Boolean representation of the input value.
+        """
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"true", "1", "yes", "y"}
+        return bool(value)
+
+    def _create_graphiti_client(self) -> Graphiti:  # pylint: disable=too-many-locals
+        """Creates and configures a Graphiti client for FalkorDB.
+
+        Initializes the Graphiti framework with FalkorDB driver and applies
+        constrained prompts to prevent entity hallucinations during graph construction.
+
+        Returns:
+            Configured Graphiti client instance ready for use.
+        """
+        graph_name = os.getenv("FALKORDB_GRAPH_NAME", "unfccc_knowledge_graph")
+
+        driver = FalkorDriver(
+            host=self.config["host"],
+            port=self.config["port"],
+            username=self.config["username"],
+            password=self.config["password"],
+            database=graph_name,
+        )
+
+        # Apply constrained prompts to prevent entity hallucinations
+        try:
+            try:
+                from . import constrained_prompts  # pylint: disable=import-outside-toplevel
+            except ImportError:
+                import sys  # pylint: disable=import-outside-toplevel
+
+                graph_rag_dir = Path(__file__).parent
+                if str(graph_rag_dir) not in sys.path:
+                    sys.path.insert(0, str(graph_rag_dir))
+                import constrained_prompts  # pylint: disable=import-error,import-outside-toplevel
+
+            import graphiti_core.prompts.extract_edges as extract_edges_module  # pylint: disable=import-outside-toplevel
+            import graphiti_core.prompts.extract_nodes as extract_nodes_module  # pylint: disable=import-outside-toplevel
+
+            extract_nodes_module.extract_text = (
+                constrained_prompts.extract_text_constrained
+            )
+            extract_edges_module.edge = constrained_prompts.extract_edges_constrained
+
+            self.logger.info("Applied constrained prompts to prevent hallucinations")
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            self.logger.warning("Failed to apply constrained prompts: %s", exc)
+            self.logger.warning(
+                "Continuing with default Graphiti prompts (may cause hallucinations)"
+            )
+
+        return Graphiti(graph_driver=driver)
+
+    def _collect_documents(self, base_dir: Path) -> List[Path]:
+        """Collects all text document files from the specified directory.
+
+        Recursively searches for .txt files if PROCESS_SUBDIRECTORIES is enabled,
+        otherwise searches only the top-level directory. Excludes hidden files
+        (those starting with '.').
+
+        Args:
+            base_dir: Directory path to search for documents.
+
+        Returns:
+            Sorted list of Path objects for all discovered text files.
+        """
+        if self.PROCESS_SUBDIRECTORIES:
+            txt_files = sorted(base_dir.rglob("*.txt"))
+        else:
+            txt_files = sorted(base_dir.glob("*.txt"))
+        return [path for path in txt_files if not path.name.startswith(".")]
+
+    def _read_text(self, path: Path) -> Optional[str]:
+        """Reads text content from a file with error handling.
+
+        Uses UTF-8 encoding and ignores decoding errors to handle potentially
+        malformed text files gracefully.
+
+        Args:
+            path: Path to the text file to read.
+
+        Returns:
+            File contents as string, or None if reading fails.
+        """
+        try:
+            return path.read_text(encoding="utf-8", errors="ignore")
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            self.logger.error("Error reading %s: %s", path, exc)
+            return None
+
+    def _extract_year_from_filename(self, path: Path) -> int:
+        """Extracts the year from a filename for temporal indexing.
+
+        Searches for a 4-digit year pattern (2000-2025) in the filename.
+        Falls back to current year if no valid year is found.
+
+        Args:
+            path: Path to the document file.
+
+        Returns:
+            Extracted year as integer, or current year as fallback.
+        """
+        match = self.YEAR_RE.search(path.stem)
+        if match:
+            year = int(match.group(1))
+            if 2000 <= year <= 2025:
+                return year
+        return datetime.now().year
+
+    def _extract_metadata_from_filename(self, path: Path) -> Dict[str, str]:
+        """Extracts conference metadata from standardized filename patterns.
+
+        Parses filenames like 'COP2015_21_Decisions.txt' to extract conference type,
+        year, and session number. Maps conference types to full names.
+
+        Args:
+            path: Path to the document file.
+
+        Returns:
+            Dictionary with extracted metadata (conference_type, year, session_number,
+            conference_name), or empty dict if pattern doesn't match.
+        """
+        metadata: Dict[str, str] = {}
+        match = self.CONFERENCE_TYPE_RE.search(path.stem)
+        if match:
+            conf_type = match.group("type").upper()
+            metadata["conference_type"] = conf_type
+            metadata["year"] = match.group("year")
+            metadata["session_number"] = match.group("session")
+            metadata["conference_name"] = self.CONFERENCE_NAMES.get(
+                conf_type, conf_type
+            )
+        return metadata
+
+    def _extract_document_metadata(self, text: str) -> Dict[str, str]:
+        """Extracts metadata from document header content.
+
+        Searches the document header for location, date, and FCCC document reference
+        information using regex patterns.
+
+        Args:
+            text: Full document text (header portion is searched).
+
+        Returns:
+            Dictionary with extracted metadata (location, date, fccc_reference).
+        """
+        header = text[:2000]
+        metadata: Dict[str, str] = {}
+
+        location_match = self.LOCATION_DATE_RE.search(header)
+        if location_match:
+            metadata["location"] = location_match.group("location").strip()
+            if location_match.group("date"):
+                metadata["date"] = location_match.group("date").strip()
+
+        fccc_match = self.FCCC_DOC_RE.search(header)
+        if fccc_match:
+            metadata["fccc_reference"] = fccc_match.group("fccc")
+        return metadata
+
+    def _split_document(  # pylint: disable=too-many-nested-blocks
+        self, raw_text: str
+    ) -> List[Dict[str, str]]:
+        """Splits a document into sections based on decision/resolution headings.
+
+        Attempts to split by decision/resolution headings first, then other heading
+        types. Separates annexes into distinct sections linked to their parent decisions.
+        Falls back to length-based splitting if no headings are found.
+
+        Args:
+            raw_text: Raw document text with potential line ending variations.
+
+        Returns:
+            List of section dictionaries with 'title' and 'body' keys.
+        """
+        text = raw_text.replace("\r\n", "\n").replace("\r", "\n")
+        text = self._strip_front_matter(text)
+
+        # Split by decisions/resolutions first, then extract annexes as separate sections
+        for regex in (self.DECISION_RESOLUTION_HEADING_RE, self.OTHER_HEADING_RE):
+            sections = self._split_by_headings(text, regex)
+            if sections:
+                final_sections = []
+                for section in sections:
+                    annex_matches = list(
+                        self.ANNEX_HEADING_RE.finditer(section["body"])
+                    )
+                    if annex_matches:
+                        first_annex_pos = annex_matches[0].start()
+
+                        # Decision content (before annex)
+                        if first_annex_pos > self.MIN_SECTION_LEN:
+                            decision_part = section["body"][:first_annex_pos].strip()
+                            final_sections.append(
+                                {"title": section["title"], "body": decision_part}
+                            )
+
+                        # Annex sections
+                        annex_text = section["body"][first_annex_pos:]
+                        annex_subsections = self._split_by_headings(
+                            annex_text, self.ANNEX_HEADING_RE
+                        )
+                        if annex_subsections:
+                            for annex_subsection in annex_subsections:
+                                annex_subsection["title"] = (
+                                    f"{annex_subsection['title']} to {section['title']}"
+                                )
+                            final_sections.extend(annex_subsections)
+                    else:
+                        final_sections.append(section)
+                return final_sections
+        return self._split_by_length(text)
+
+    def _strip_front_matter(self, text: str) -> str:
+        """Removes front matter (table of contents, headers) from document text.
+
+        Identifies the first substantive heading (decision/resolution) or known
+        front matter markers and returns text starting from that point.
+
+        Args:
+            text: Full document text including front matter.
+
+        Returns:
+            Document text with front matter removed.
+        """
+        first_idx = len(text)
+        for regex in (self.DECISION_RESOLUTION_HEADING_RE, self.OTHER_HEADING_RE):
+            match = regex.search(text)
+            if match:
+                first_idx = min(first_idx, match.start())
+        if first_idx < len(text):
+            return text[first_idx:]
+        for marker in self.FRONT_MATTER_MARKERS:
+            position = text.find(marker)
+            if 0 <= position < len(text):
+                return text[position:]
+        return text
+
+    def _split_by_headings(
+        self, text: str, heading_re: re.Pattern
+    ) -> List[Dict[str, str]]:
+        """Splits text into sections based on a heading pattern.
+
+        Finds all matches of the heading pattern and extracts the text between
+        consecutive headings as section bodies. Filters out sections that are
+        too short (below MIN_SECTION_LEN).
+
+        Args:
+            text: Text to split into sections.
+            heading_re: Compiled regex pattern for identifying headings.
+
+        Returns:
+            List of section dictionaries with 'title' and 'body' keys, or empty
+            list if no headings match.
+        """
+        matches = list(heading_re.finditer(text))
+        if not matches:
+            return []
+
+        sections: List[Dict[str, str]] = []
+        starts = [match.start() for match in matches] + [len(text)]
+        titles = [match.group("h").strip() for match in matches]
+
+        for idx, title in enumerate(titles):
+            start = matches[idx].start()
+            end = starts[idx + 1]
+            block = text[start:end].strip()
+            if not block:
+                continue
+
+            lines = block.splitlines()
+            first_line = lines[0].strip() if lines else ""
+            body = (
+                "\n".join(lines[1:]).strip()
+                if first_line == title and len(lines) > 1
+                else block
+            )
+            if len(body) < self.MIN_SECTION_LEN:
+                continue
+
+            if self.INCLUDE_HEADING_IN_BODY:
+                body = f"{title}\n\n{body}".strip()
+            sections.append({"title": title, "body": body})
+        return sections
+
+    def _split_by_length(self, text: str) -> List[Dict[str, str]]:
+        """Splits text into fixed-length chunks as a fallback strategy.
+
+        Used when no recognizable headings are found. Creates sections of
+        FALLBACK_CHARS length, filtering out sections that are too short.
+
+        Args:
+            text: Text to split into chunks.
+
+        Returns:
+            List of section dictionaries with auto-generated 'title' (e.g., 'Part 1')
+            and 'body' keys.
+        """
+        sections: List[Dict[str, str]] = []
+        for idx in range(0, len(text), self.FALLBACK_CHARS):
+            chunk = text[idx : idx + self.FALLBACK_CHARS].strip()
+            if len(chunk) < self.MIN_SECTION_LEN:
+                continue
+            sections.append(
+                {"title": f"Part {idx // self.FALLBACK_CHARS + 1}", "body": chunk}
+            )
+        return sections
+
+    def _build_source_description(
+        self, path: Path, metadata: Dict[str, str], year: int
+    ) -> str:
+        """Builds a human-readable source description for episodes.
+
+        Creates a formatted description like 'Conference of the Parties Session 21 (2015)'
+        if metadata is available, otherwise uses the filename.
+
+        Args:
+            path: Path to source document file.
+            metadata: Extracted metadata dictionary.
+            year: Document year.
+
+        Returns:
+            Formatted source description string.
+        """
+        if metadata.get("conference_name"):
+            return (
+                f"{metadata['conference_name']} "
+                f"Session {metadata.get('session_number', 'N/A')} "
+                f"({metadata.get('year', year)})"
+            )
+        return path.stem
+
+    def _build_episode_body(self, section_body: str, metadata: Dict[str, str]) -> str:
+        """Builds episode body text with metadata headers.
+
+        Prepends conference, session, year, location, and document reference
+        information to the section body for context.
+
+        Args:
+            section_body: The main text content of the section.
+            metadata: Metadata dictionary with conference information.
+
+        Returns:
+            Formatted episode body with metadata headers and section content.
+        """
+        header_lines: List[str] = []
+        if metadata.get("conference_name"):
+            header_lines.append(f"Conference: {metadata['conference_name']}")
+        if metadata.get("session_number"):
+            header_lines.append(f"Session: {metadata['session_number']}")
+        if metadata.get("year"):
+            header_lines.append(f"Year: {metadata['year']}")
+        if metadata.get("location"):
+            header_lines.append(f"Location: {metadata['location']}")
+        if metadata.get("fccc_reference"):
+            header_lines.append(f"Document: {metadata['fccc_reference']}")
+
+        if not header_lines:
+            return section_body
+        return "\n".join(header_lines) + "\n\n" + section_body
+
+    def _limit_episodes(self, episodes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Limits the number of episodes to process based on MAX_EPISODES configuration.
+
+        Used for testing or partial processing. Returns all episodes if MAX_EPISODES
+        is 0 or exceeds the episode count.
+
+        Args:
+            episodes: Full list of prepared episodes.
+
+        Returns:
+            Truncated or full episode list based on MAX_EPISODES setting.
+        """
+        max_episodes = self.config["max_episodes"]
+        if 0 < max_episodes < len(episodes):
+            self.logger.info(
+                "Limiting to first %d episodes (MAX_EPISODES is set)", max_episodes
+            )
+            return episodes[:max_episodes]
+        return episodes
+
+    def _log_episode_stats(self, episodes: List[Dict[str, Any]]) -> None:
+        """Logs statistical summary of prepared episodes.
+
+        Reports total episode count, distribution by conference type and year,
+        episode types (decisions vs annexes), and paragraph indexing statistics.
+
+        Args:
+            episodes: List of prepared episode dictionaries.
+        """
+        self.logger.info("Successfully prepared %d episodes", len(episodes))
+
+        conf_types: Dict[str, int] = {}
+        years: Dict[str, int] = {}
+        total_paragraphs = 0
+        episodes_with_paragraphs = 0
+        decision_count = 0
+        annex_count = 0
+
+        for episode in episodes:
+            metadata = episode.get("metadata", {})
+            if "conference_type" in metadata:
+                conf_type = metadata["conference_type"]
+                conf_types[conf_type] = conf_types.get(conf_type, 0) + 1
+                year = metadata.get("year", "Unknown")
+                years[year] = years.get(year, 0) + 1
+
+            paragraph_index = metadata.get("paragraph_index", {})
+            if paragraph_index:
+                episodes_with_paragraphs += 1
+                total_paragraphs += len(paragraph_index)
+
+            if episode.get("decision_id"):
+                decision_count += 1
+            if episode.get("annex_id"):
+                annex_count += 1
+
+        if conf_types:
+            self.logger.info("Episode distribution by conference: %s", conf_types)
+        if years:
+            ordered_years = dict(sorted(years.items(), key=lambda entry: entry[0]))
+            self.logger.info("Episode distribution by year: %s", ordered_years)
+
+        self.logger.info(
+            "Episode types: %d decisions, %d annexes, %d other",
+            decision_count,
+            annex_count,
+            len(episodes) - decision_count - annex_count,
+        )
+
+        if episodes_with_paragraphs > 0:
+            avg_paragraphs = total_paragraphs / episodes_with_paragraphs
+            self.logger.info(
+                "Paragraph indexing: %d episodes with %d total paragraphs (avg: %.1f per episode)",
+                episodes_with_paragraphs,
+                total_paragraphs,
+                avg_paragraphs,
+            )
+
+    async def _add_episodes(  # pylint: disable=too-many-locals
+        self, graphiti: Graphiti, episodes: List[Dict[str, Any]]
+    ) -> Tuple[int, List[Tuple[str, str]]]:
+        """Adds episodes to the knowledge graph with checkpoint-based resume.
+
+        Processes episodes sequentially, writing checkpoints after each success to
+        enable resumption after interruptions. Skips already-processed episodes.
+
+        Args:
+            graphiti: The Graphiti client instance for adding episodes.
+            episodes: List of episode dictionaries to process.
+
+        Returns:
+            Tuple of (success_count, failures_list) where failures is a list of
+            (episode_name, error_message) tuples.
+        """
+        success_count = 0
+        failures: List[Tuple[str, str]] = []
+        start_time = datetime.now()
+
+        checkpoint_file = Path(__file__).parent / ".ingestion_checkpoint.txt"
+        processed_episodes = set()
+        if checkpoint_file.exists():
+            with open(checkpoint_file, "r", encoding="utf-8") as f:
+                for line in f:
+                    episode_name = line.rstrip("\n")
+                    if episode_name:
+                        processed_episodes.add(episode_name)
+            self.logger.info(
+                "\nCheckpoint found: %d episodes already processed",
+                len(processed_episodes)
+            )
+            self.logger.info("Will skip these and continue from where you left off\n")
+
+        skipped_count = 0
+        for idx, episode in enumerate(episodes, 1):
+            episode_name = episode["name"]
+
+            if episode_name in processed_episodes:
+                skipped_count += 1
+                if skipped_count % 50 == 0:
+                    self.logger.info("Skipped %d already-processed episodes...", skipped_count)
+                continue
+
+            try:
+                self.logger.info("\n[%d/%d] Processing episode: %s", idx, len(episodes), episode_name)
+                self.logger.info("    Source: %s", episode['source_description'])
+
+                await graphiti.add_episode(
+                    name=episode_name,
+                    episode_body=episode["episode_body"],
+                    source=EpisodeType.text,
+                    source_description=episode["source_description"],
+                    reference_time=episode["reference_time"],
+                )
+                success_count += 1
+                self.logger.info("    ✓ Successfully added")
+
+                with open(checkpoint_file, "a", encoding="utf-8") as f:
+                    f.write(f"{episode_name}\n")
+
+                if idx % self.config["batch_size"] == 0:
+                    self._log_progress(idx, len(episodes), start_time)
+                elif self.config["verbose_logging"]:
+                    self.logger.info("Added episode %d/%d: %s", idx, len(episodes), episode_name[:100])
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                failure = (episode_name, str(exc))
+                failures.append(failure)
+                self.logger.error("Failed to add episode %s: %s", episode_name, exc)
+
+        self._log_summary(len(episodes), success_count, failures, start_time)
+        return success_count, failures
+
+    def _log_progress(self, completed: int, total: int, start_time: datetime) -> None:
+        """Logs processing progress with rate and ETA calculations.
+
+        Args:
+            completed: Number of episodes processed so far.
+            total: Total number of episodes to process.
+            start_time: Processing start timestamp for rate calculations.
+        """
+        elapsed = (datetime.now() - start_time).total_seconds()
+        rate = completed / elapsed if elapsed > 0 else 0
+        remaining = total - completed
+        eta = remaining / rate if rate > 0 else 0
+        percentage = completed / total * 100 if total else 0
+        self.logger.info(
+            "Progress: %d/%d episodes added (%.1f%%) - Rate: %.1f eps/sec - ETA: %.1f min",
+            completed,
+            total,
+            percentage,
+            rate,
+            eta / 60,
+        )
+
+    def _log_summary(
+        self,
+        total: int,
+        success_count: int,
+        failures: List[Tuple[str, str]],
+        start_time: datetime,
+    ) -> None:
+        """Logs final processing summary with statistics.
+
+        Args:
+            total: Total number of episodes attempted.
+            success_count: Number of episodes successfully processed.
+            failures: List of (episode_name, error_message) tuples for failures.
+            start_time: Processing start timestamp for duration calculation.
+        """
+        elapsed_total = (datetime.now() - start_time).total_seconds()
+        success_rate = success_count / total * 100 if total else 0
+        average_rate = success_count / elapsed_total if elapsed_total else 0
+        self.logger.info("\n%s", "=" * 80)
+        self.logger.info("EPISODE LOADING SUMMARY")
+        self.logger.info("%s", "=" * 80)
+        self.logger.info("Total episodes processed: %d", total)
+        self.logger.info("Successfully added: %d", success_count)
+        self.logger.info("Failed: %d", len(failures))
+        self.logger.info("Success rate: %.1f%%", success_rate)
+        self.logger.info(
+            "Total time: %.1f minutes", elapsed_total / 60 if elapsed_total else 0
+        )
+        self.logger.info("Average rate: %.2f episodes/second", average_rate)
+
+    def _print_section(self, title: str, double_space: bool = False) -> None:
+        """Prints a formatted section header with consistent styling.
+
+        Args:
+            title: The section title to display.
+            double_space: If True, adds extra newline before the section header.
+        """
+        prefix = "\n\n" if double_space else "\n"
+        self.logger.info("%s%s", prefix, "=" * 80)
+        self.logger.info("%s", title)
+        self.logger.info("%s", "=" * 80)
+
+    async def _run_demo_searches(self, graphiti: Graphiti) -> None:
+        """Executes all demonstration search queries to showcase knowledge graph capabilities.
+
+        Runs climate queries, node searches, reference traversal demonstrations,
+        temporal queries, and paragraph-level access examples.
+
+        Args:
+            graphiti: The Graphiti client instance for executing queries.
+        """
+        self._print_section("CLIMATE CONFERENCE KNOWLEDGE GRAPH SEARCH RESULTS")
+        await self._run_climate_queries(graphiti)
+        await self._run_node_queries(graphiti)
+        await self._demo_reference_traversal(graphiti)
+        await self._demo_temporal_queries(graphiti)
+        await self._demo_paragraph_access(graphiti)
+
+    async def _run_climate_queries(self, graphiti: Graphiti) -> None:
+        """Executes predefined climate-related search queries.
+
+        Demonstrates semantic search capabilities on climate conference decisions,
+        including queries about the Paris Agreement, climate finance, adaptation,
+        mitigation, and Article 6 mechanisms.
+
+        Args:
+            graphiti: The Graphiti client instance for executing queries.
+        """
+        for query in self.CLIMATE_QUERIES:
+            self._print_section(f"QUERY: {query}", double_space=True)
+            try:
+                results = await graphiti.search(query)
+                results = (results or [])[: self.config["search_limit"]]
+                if results:
+                    self.logger.info("\nFound %d results:\n", len(results))
+                    for idx, result in enumerate(results, 1):
+                        self.logger.info("\n--- Result %d ---", idx)
+                        self.logger.info("Fact: %s", result.fact)
+                        if getattr(result, "valid_at", None):
+                            self.logger.info("Valid from: %s", result.valid_at)
+                        if getattr(result, "invalid_at", None):
+                            self.logger.info("Valid until: %s", result.invalid_at)
+                else:
+                    self.logger.info("\nNo results found for this query.")
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                self.logger.error('Search failed for query "%s": %s', query, exc)
+
+    async def _run_node_queries(self, graphiti: Graphiti) -> None:
+        """Performs node-based searches for key climate topics.
+
+        Uses hybrid search with reciprocal rank fusion to find the most relevant
+        entities in the knowledge graph for topics like climate finance, adaptation,
+        mitigation, and the Paris Agreement.
+
+        Args:
+            graphiti: The Graphiti client instance for executing queries.
+        """
+        self._print_section("NODE SEARCH: Key Climate Topics", double_space=True)
+
+        for query in self.NODE_QUERIES:
+            self.logger.info("\n--- Searching nodes for: %s ---", query)
+            try:
+                node_search_config = NODE_HYBRID_SEARCH_RRF.model_copy(deep=True)
+                node_search_config.limit = 3
+                node_search_results = (
+                    await graphiti._search(  # pylint: disable=protected-access
+                        query=query,
+                        config=node_search_config,
+                    )
+                )
+                if node_search_results.nodes:
+                    for node in node_search_results.nodes:
+                        self.logger.info("\n  Node: %s", node.name)
+                        summary = (node.summary or "").strip()
+                        summary = (
+                            summary[:150] + "..." if len(summary) > 150 else summary
+                        )
+                        self.logger.info("  Summary: %s", summary)
+                        self.logger.info("  Labels: %s", ', '.join(node.labels))
+                else:
+                    self.logger.info("  No nodes found.")
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                self.logger.error('Node search failed for "%s": %s', query, exc)
+
+    async def _demo_reference_traversal(self, graphiti: Graphiti) -> None:
+        """Demonstrates cross-document reference traversal capabilities.
+
+        Shows how decisions reference other decisions, articles, and paragraphs,
+        enabling navigation through the interconnected web of climate conference
+        decisions and legal instruments.
+
+        Args:
+            graphiti: The Graphiti client instance (not used in this demo).
+        """
+        del graphiti  # Not needed for this demo method
+        self._print_section("REFERENCE TRAVERSAL DEMO", double_space=True)
+
+        # Show some sample references
+        sample_count = 0
+        for episode_name, refs in list(self.reference_map.items())[:3]:
+            self.logger.info("\n--- Episode: %s ---", episode_name[:80])
+            self.logger.info("References %d other decisions/articles:", len(refs))
+            for ref in refs[:5]:  # Show first 5 references
+                if ref["type"] == "decision":
+                    ref_text = f"  → Decision {ref['target']}"
+                    if ref.get("paragraphs"):
+                        ref_text += f", paragraph(s) {ref['paragraphs']}"
+                    self.logger.info("%s", ref_text)
+                elif ref["type"] == "article":
+                    ref_text = f"  → Article {ref['target']}"
+                    if ref.get("agreement"):
+                        ref_text += f" of {ref['agreement']}"
+                    if ref.get("paragraphs"):
+                        ref_text += f", paragraph(s) {ref['paragraphs']}"
+                    self.logger.info("%s", ref_text)
+            sample_count += 1
+            if sample_count >= 3:
+                break
+
+    async def _demo_temporal_queries(  # pylint: disable=too-many-locals,too-many-branches,too-many-nested-blocks
+        self, graphiti: Graphiti
+    ) -> None:
+        """Demonstrates temporal query capabilities for tracking decision evolution.
+
+        Shows how to query decisions by year, analyze temporal ranges, visualize
+        decision timelines, and track how climate policy approaches evolved over time.
+        Includes examples of querying decision trends from specific time periods.
+
+        Args:
+            graphiti: The Graphiti client instance for executing queries.
+        """
+        self._print_section("TEMPORAL QUERY DEMO", double_space=True)
+
+        # Build temporal index from decision registry
+        decisions_by_year: Dict[str, List[str]] = defaultdict(list)
+        for decision_id, episode_name in self.decision_registry.items():
+            # Extract year from metadata if available
+            for episode_name_iter, refs in self.reference_map.items():
+                if episode_name_iter == episode_name and refs:
+                    # Get year from first reference's context or episode metadata
+                    break
+            # Extract year from decision ID (e.g., "15/CMA.1" -> session 1 -> typically 2018)
+            # Or from episode name which contains year
+            if "::" in episode_name:
+                filename_part = episode_name.split("::")[0]
+                # Extract year from filename (e.g., "CMA2018_1.3_Decisions")
+                year_match = re.search(r"(\d{4})", filename_part)
+                if year_match:
+                    year = year_match.group(1)
+                    decisions_by_year[year].append(decision_id)
+
+        if not decisions_by_year:
+            self.logger.info("\nNo temporal data available for demo.")
+            return
+
+        self.logger.info("\nDecisions by year:")
+        sorted_years = sorted(decisions_by_year.keys())
+        for year in sorted_years:
+            self.logger.info("%s: %d decisions", year, len(decisions_by_year[year]))
+
+        # Demo: Show decisions from a specific time period
+        self._print_section("TEMPORAL RANGE QUERY DEMO")
+
+        # Example: Show decisions from 2020-2022
+        start_year = "2020"
+        end_year = "2022"
+        decisions_in_range = []
+        for year in sorted_years:
+            if start_year <= year <= end_year:
+                decisions_in_range.extend(decisions_by_year[year])
+
+        if decisions_in_range:
+            self.logger.info(
+                "\nDecisions from %s to %s: %d total",
+                start_year, end_year, len(decisions_in_range)
+            )
+            self.logger.info("\nSample decisions from this period:")
+            for decision_id in decisions_in_range[:10]:
+                self.logger.info("  • %s", decision_id)
+            if len(decisions_in_range) > 10:
+                self.logger.info("  ... and %d more", len(decisions_in_range) - 10)
+
+        # Demo: Timeline evolution query
+        self._print_section("TEMPORAL EVOLUTION QUERY")
+
+        # Check if we have decisions across multiple years
+        if len(sorted_years) >= 2:
+            self.logger.info("\nTimeline: %s to %s", sorted_years[0], sorted_years[-1])
+            self.logger.info(
+                "Total span: %d years",
+                int(sorted_years[-1]) - int(sorted_years[0]) + 1
+            )
+            self.logger.info("\nDecisions per year:")
+            for year in sorted_years:
+                count = len(decisions_by_year[year])
+                bar_chart = "█" * min(count, 50)
+                self.logger.info("  %s: %s (%d)", year, bar_chart, count)
+
+        # Demo: Query with temporal context
+        self._print_section("QUERYING WITH TEMPORAL CONTEXT")
+
+        temporal_queries = [
+            (
+                f"What decisions were made about climate finance "
+                f"between {sorted_years[0]} and {sorted_years[-1]}?"
+            ),
+            (
+                f"How did the approach to adaptation evolve "
+                f"from {sorted_years[0]} to {sorted_years[-1]}?"
+            ),
+        ]
+
+        for query in temporal_queries[:1]:  # Just run one to avoid too much output
+            self.logger.info("\nQuery: %s", query)
+            try:
+                results = await graphiti.search(query)
+                results = (results or [])[:3]
+                if results:
+                    self.logger.info("Found %d results (showing top 3):", len(results))
+                    for idx, result in enumerate(results, 1):
+                        fact_preview = (
+                            result.fact[:150] + "..."
+                            if len(result.fact) > 150
+                            else result.fact
+                        )
+                        self.logger.info("  %d. %s", idx, fact_preview)
+                else:
+                    self.logger.info("No results found.")
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                self.logger.error("Temporal query failed: %s", exc)
+
+    async def _demo_paragraph_access(  # pylint: disable=too-many-locals
+        self, graphiti: Graphiti
+    ) -> None:
+        """Demonstrates paragraph-level granular access and citation resolution.
+
+        Shows how the system provides direct access to specific paragraphs within
+        decisions, enabling precise citation resolution (e.g., 'paragraph 69 of
+        decision 1/CP.21') without searching full text. Demonstrates the paragraph
+        indexing functionality that enables efficient granular retrieval.
+
+        Args:
+            graphiti: The Graphiti client instance for executing queries.
+        """
+        self._print_section("PARAGRAPH-LEVEL ACCESS DEMO", double_space=True)
+
+        # Find episodes with paragraph indices
+        episodes_with_paragraphs = []
+        for decision_id, episode_name in self.decision_registry.items():
+            # Check if this episode has references with paragraph numbers
+            refs = self.reference_map.get(episode_name, [])
+            has_para_refs = any(ref.get("paragraphs") for ref in refs)
+            if has_para_refs:
+                episodes_with_paragraphs.append((decision_id, episode_name, refs))
+
+        if not episodes_with_paragraphs:
+            self.logger.info("\nNo paragraph-level references found in demo.")
+            return
+
+        self.logger.info(
+            "\nFound %d decisions with paragraph-level references",
+            len(episodes_with_paragraphs)
+        )
+
+        # Show a few examples
+        self._print_section("EXAMPLE: Decisions Referencing Specific Paragraphs")
+
+        for decision_id, episode_name, refs in episodes_with_paragraphs[:3]:
+            self.logger.info("\n--- Decision: %s ---", decision_id)
+
+            # Show paragraph references this decision makes
+            para_refs = [ref for ref in refs if ref.get("paragraphs")]
+            if para_refs:
+                self.logger.info("This decision references specific paragraphs in:")
+                for ref in para_refs[:5]:
+                    target = ref.get("target", "unknown")
+                    paras = ref.get("paragraphs", "")
+                    self.logger.info("  • %s, paragraph(s) %s", target, paras)
+
+        # Example query demonstration
+        self._print_section("EXAMPLE PARAGRAPH-LEVEL QUERY")
+
+        # Pick a decision with paragraph references to demonstrate
+        if episodes_with_paragraphs:
+            decision_id, episode_name, refs = episodes_with_paragraphs[0]
+            para_ref = next((ref for ref in refs if ref.get("paragraphs")), None)
+
+            if para_ref:
+                target = para_ref.get("target")
+                paras = para_ref.get("paragraphs")
+                query = f"What does paragraph {paras} of decision {target} say?"
+
+                self.logger.info("\nQuery: %s", query)
+                try:
+                    # Actually run the query
+                    results = await graphiti.search(query)
+                    results = (results or [])[:2]
+
+                    if results:
+                        self.logger.info("\nResults found: %d", len(results))
+                        for idx, result in enumerate(results, 1):
+                            fact_preview = (
+                                result.fact[:200] + "..."
+                                if len(result.fact) > 200
+                                else result.fact
+                            )
+                            self.logger.info("\n  Result %d:", idx)
+                            self.logger.info("  %s", fact_preview)
+                    else:
+                        self.logger.info(
+                            "\nNo results found (decision may not be in current batch)"
+                        )
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    self.logger.error("Paragraph query failed: %s", exc)
+
+    def _log_demo_skipped_reason(self, success_count: int) -> None:
+        """Logs the reason why demo searches were skipped.
+
+        Args:
+            success_count: Number of episodes successfully added to the graph.
+        """
+        if not self.config["enable_demo_searches"]:
+            self.logger.info("Demo searches disabled (ENABLE_DEMO_SEARCHES=false)")
+        elif success_count == 0:
+            self.logger.info(
+                "Skipping demo searches (no episodes were successfully added)"
+            )
+
+
+async def main() -> None:
+    """Standalone entry point for manual execution.
+
+    Creates a FalkorDBIngestionEnhanced instance with default configuration
+    from environment variables and runs the complete ingestion pipeline.
+    """
+    runner = FalkorDBIngestionEnhanced()
+    await runner.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/coded_tools/graph_rag/graph_search_tool.py
+++ b/coded_tools/graph_rag/graph_search_tool.py
@@ -1,0 +1,390 @@
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+"""
+Graph search tool for UNFCCC climate documents using FalkorDB knowledge graph.
+
+This module implements a Graph-based Retrieval-Augmented Generation (RAG) tool that provides
+semantic search capabilities over a knowledge graph of climate conference documents stored in
+FalkorDB. It leverages the Graphiti library to perform hybrid search (combining vector similarity
+and keyword matching) over entities and relationships extracted from UNFCCC documents including
+COP, CMA, CMP, SBI, and SBSTA proceedings.
+
+Architecture:
+    - Uses Graphiti Core for graph operations and hybrid search
+    - Connects to FalkorDB (Redis-based graph database) for knowledge storage
+    - Implements singleton pattern for graph connections (shared across invocations)
+    - Supports three search modes: general facts, entities, and relationships
+    - Automatically enriches results with connected nodes and relationships
+
+Search Types:
+    1. "general" (default): Searches for general facts and relationships in the graph.
+       Returns facts with connected entity details.
+
+    2. "entity": Searches for entity nodes (e.g., countries, organizations, concepts).
+       Returns entities with their summaries and connected relationships.
+
+    3. "relationship": Searches for relationship edges between entities.
+       Returns relationships with source and target entity details.
+"""
+import os
+import traceback
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from dotenv import load_dotenv
+from neuro_san.interfaces.coded_tool import CodedTool
+
+# Load environment variables BEFORE importing graphiti
+_current_dir = Path(__file__).parent
+load_dotenv(dotenv_path=_current_dir / ".env")
+
+from graphiti_core import Graphiti
+from graphiti_core.driver.falkordb_driver import FalkorDriver
+
+
+class GraphSearchTool(CodedTool):
+    """
+    Graph-based RAG tool for semantic search over UNFCCC climate documents.
+
+    Performs hybrid search (vector + keyword) over knowledge graph stored in FalkorDB.
+    Supports three search modes: general facts, entities, and relationships.
+    """
+
+    # Class-level instances shared across all invocations
+    _graphiti_instance: Optional[Graphiti] = None
+    _driver_instance: Optional[FalkorDriver] = None
+
+    async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> str:
+        """
+        Execute graph relationship search and return relevant facts.
+
+        :param args: Dictionary with query and optional parameters
+        :param sly_data: Additional context data (not used)
+        :return: Formatted string with retrieved graph facts
+        """
+        try:
+            # Initialize graph if needed
+            if GraphSearchTool._graphiti_instance is None:
+                await self._initialize_graph()
+
+            # Extract and validate arguments
+            query: str = args.get("query")
+            if not query:
+                return "Error: query parameter is required"
+
+            # Convert string inputs to appropriate types
+            limit: int = int(args.get("limit", 10))
+            search_type: str = args.get("search_type", "general")
+
+            # Perform search based on type
+            if search_type == "entity":
+                results: List[Any] = await self._search_entities(query, limit)
+                formatted_output: str = await self._format_entities(query, results)
+            elif search_type == "relationship":
+                results = await self._search_relationships(query, limit)
+                formatted_output = await self._format_relationships(query, results)
+            else:
+                results = await self._search_graph(query, limit)
+                formatted_output = await self._format_facts(query, results)
+
+            return formatted_output
+
+        # pylint: disable=broad-exception-caught
+        except Exception as exception:
+            error_msg: str = f"Error executing graph search: {str(exception)}"
+            traceback.print_exc()
+            return error_msg
+
+    async def _initialize_graph(self) -> None:
+        """
+        Initialize FalkorDB connection and Graphiti instance.
+
+        :return: None
+        """
+        GraphSearchTool._driver_instance = FalkorDriver(
+            host=os.getenv("FALKORDB_HOST", "localhost"),
+            port=int(os.getenv("FALKORDB_PORT", "6379")),
+            username=os.getenv("FALKORDB_USERNAME"),
+            password=os.getenv("FALKORDB_PASSWORD"),
+            database=os.getenv("GRAPH_NAME", "unfccc_knowledge_graph"),
+        )
+
+        GraphSearchTool._graphiti_instance = Graphiti(
+            graph_driver=GraphSearchTool._driver_instance
+        )
+
+    async def _search_graph(self, query: str, limit: int) -> List[Any]:
+        """
+        Search graph for general facts and relationships.
+
+        :param query: Search query text
+        :param limit: Maximum number of results
+        :return: List of search results
+        """
+        results = await GraphSearchTool._graphiti_instance.search(
+            query=query, num_results=limit
+        )
+        return results or []
+
+    async def _search_entities(self, query: str, limit: int) -> List[Any]:
+        """
+        Search for entity nodes in the graph.
+
+        :param query: Search query text
+        :param limit: Maximum number of results
+        :return: List of entity nodes
+        """
+        from graphiti_core.search.search_config_recipes import \
+            NODE_HYBRID_SEARCH_RRF
+
+        config = NODE_HYBRID_SEARCH_RRF.model_copy(deep=True)
+        config.limit = limit
+
+        results = await GraphSearchTool._graphiti_instance._search(
+            query=query, config=config
+        )
+
+        return results.nodes if results and results.nodes else []
+
+    async def _search_relationships(self, query: str, limit: int) -> List[Any]:
+        """
+        Search for relationship edges in the graph.
+
+        :param query: Search query text
+        :param limit: Maximum number of results
+        :return: List of relationship edges
+        """
+        from graphiti_core.search.search_config_recipes import \
+            EDGE_HYBRID_SEARCH_RRF
+
+        config = EDGE_HYBRID_SEARCH_RRF.model_copy(deep=True)
+        config.limit = limit
+
+        results = await GraphSearchTool._graphiti_instance._search(
+            query=query, config=config
+        )
+
+        return results.edges if results and results.edges else []
+
+    async def _format_facts(self, query: str, results: List[Any]) -> str:
+        """
+        Format general graph facts with connected node details.
+
+        :param query: Original search query
+        :param results: List of graph fact results
+        :return: Formatted string representation
+        """
+        if not results:
+            return f"No graph facts found matching query: {query}"
+
+        output_parts: List[str] = [
+            f"Found {len(results)} relevant facts for query: '{query}'\n",
+            "=" * 80,
+            "",
+        ]
+
+        for i, result in enumerate(results, 1):
+            fact: str = result.fact
+            name: str = getattr(result, "name", "")
+            source_uuid: Optional[str] = getattr(result, "source_node_uuid", None)
+            target_uuid: Optional[str] = getattr(result, "target_node_uuid", None)
+
+            output_parts.append(f"FACT {i}")
+            if name:
+                output_parts.append(f"Relationship Type: {name}")
+            output_parts.append(f"Statement: {fact}")
+
+            # Get connected node details
+            if source_uuid and target_uuid:
+                source_node: Dict[str, Any] = await self._get_node_by_uuid(source_uuid)
+                target_node: Dict[str, Any] = await self._get_node_by_uuid(target_uuid)
+
+                if source_node or target_node:
+                    output_parts.append("\nConnected Entities:")
+                    if source_node:
+                        output_parts.append(
+                            f"  From: {source_node.get('name', 'Unknown')}"
+                        )
+                        if source_node.get("summary"):
+                            output_parts.append(f"       {source_node['summary']}")
+                    if target_node:
+                        output_parts.append(
+                            f"  To: {target_node.get('name', 'Unknown')}"
+                        )
+                        if target_node.get("summary"):
+                            output_parts.append(f"      {target_node['summary']}")
+
+            output_parts.append("")
+            output_parts.append("-" * 80)
+            output_parts.append("")
+
+        return "\n".join(output_parts)
+
+    async def _get_node_by_uuid(self, uuid: str) -> Dict[str, Any]:
+        """
+        Fetch node details by UUID.
+
+        :param uuid: Node UUID to look up
+        :return: Dictionary with node details or empty dict if not found
+        """
+        if not self._driver_instance:
+            return {}
+
+        try:
+            query: str = """
+            MATCH (n:Entity {uuid: $uuid})
+            RETURN n.name as name, n.summary as summary, n.entity_type as entity_type, labels(n) as labels
+            LIMIT 1
+            """
+            records, _, _ = await self._driver_instance.execute_query(query, uuid=uuid)
+            if records:
+                return dict(records[0])
+            return {}
+        # pylint: disable=broad-exception-caught
+        except Exception:
+            return {}
+
+    async def _format_entities(self, query: str, results: List[Any]) -> str:
+        """
+        Format entity nodes with connected relationships.
+
+        :param query: Original search query
+        :param results: List of entity node results
+        :return: Formatted string representation
+        """
+        if not results:
+            return f"No entities found matching query: {query}"
+
+        output_parts: List[str] = [
+            f"Found {len(results)} relevant entities for query: '{query}'\n",
+            "=" * 80,
+            "",
+        ]
+
+        for i, node in enumerate(results, 1):
+            name: str = node.name
+            summary: str = getattr(node, "summary", "")
+            labels: List[str] = getattr(node, "labels", [])
+            entity_type: str = getattr(node, "entity_type", "")
+            uuid: str = getattr(node, "uuid", "")
+
+            output_parts.append(f"ENTITY {i}: {name}")
+
+            if entity_type:
+                output_parts.append(f"Type: {entity_type}")
+            elif labels:
+                output_parts.append(f"Type: {', '.join(labels)}")
+
+            if summary:
+                output_parts.append(f"\nDescription: {summary}")
+
+            # Get connected relationships
+            if uuid:
+                connections: List[Dict[str, Any]] = await self._get_entity_connections(
+                    uuid
+                )
+                if connections:
+                    output_parts.append(
+                        f"\nConnected to ({len(connections)} relationships):"
+                    )
+                    for (
+                        conn
+                    ) in connections:  # Show all connections (limited to 5 in query)
+                        output_parts.append(
+                            f"  - {conn['relationship']}: {conn['target_name']}"
+                        )
+
+            output_parts.append("")
+            output_parts.append("-" * 80)
+            output_parts.append("")
+
+        return "\n".join(output_parts)
+
+    async def _get_entity_connections(self, uuid: str) -> List[Dict[str, Any]]:
+        """
+        Get relationships connected to an entity.
+
+        :param uuid: Entity UUID to find connections for
+        :return: List of connection dictionaries
+        """
+        if not self._driver_instance:
+            return []
+
+        try:
+            query: str = """
+            MATCH (source:Entity {uuid: $uuid})-[r:RELATES_TO]->(target:Entity)
+            RETURN r.name as relationship, target.name as target_name, r.fact as fact
+            LIMIT 5
+            """
+            records, _, _ = await self._driver_instance.execute_query(query, uuid=uuid)
+            return [dict(record) for record in records]
+        # pylint: disable=broad-exception-caught
+        except Exception:
+            return []
+
+    async def _format_relationships(self, query: str, results: List[Any]) -> str:
+        """
+        Format relationship edges with connected entity details.
+
+        :param query: Original search query
+        :param results: List of relationship edge results
+        :return: Formatted string representation
+        """
+        if not results:
+            return f"No relationships found matching query: {query}"
+
+        output_parts: List[str] = [
+            f"Found {len(results)} relevant relationships for query: '{query}'\n",
+            "=" * 80,
+            "",
+        ]
+
+        for i, edge in enumerate(results, 1):
+            fact: str = edge.fact
+            name: str = getattr(edge, "name", "")
+            source_uuid: Optional[str] = getattr(edge, "source_node_uuid", None)
+            target_uuid: Optional[str] = getattr(edge, "target_node_uuid", None)
+
+            output_parts.append(f"RELATIONSHIP {i}")
+            if name:
+                output_parts.append(f"Type: {name}")
+
+            output_parts.append(f"Description: {fact}")
+
+            # Get connected entity details
+            if source_uuid and target_uuid:
+                source_node: Dict[str, Any] = await self._get_node_by_uuid(source_uuid)
+                target_node: Dict[str, Any] = await self._get_node_by_uuid(target_uuid)
+
+                if source_node or target_node:
+                    output_parts.append("\nConnected Entities:")
+                    if source_node:
+                        output_parts.append(
+                            f"  From: {source_node.get('name', 'Unknown')}"
+                        )
+                        if source_node.get("summary"):
+                            output_parts.append(f"        {source_node['summary']}")
+                    if target_node:
+                        output_parts.append(
+                            f"  To: {target_node.get('name', 'Unknown')}"
+                        )
+                        if target_node.get("summary"):
+                            output_parts.append(f"      {target_node['summary']}")
+
+            output_parts.append("")
+            output_parts.append("-" * 80)
+            output_parts.append("")
+
+        return "\n".join(output_parts)

--- a/coded_tools/graph_rag/graph_search_tool.py
+++ b/coded_tools/graph_rag/graph_search_tool.py
@@ -10,20 +10,25 @@
 # END COPYRIGHT
 
 """
-Graph search tool for UNFCCC climate documents using FalkorDB knowledge graph.
+Graph search tool for UNFCCC climate documents using Neo4j or FalkorDB knowledge graph.
 
 This module implements a Graph-based Retrieval-Augmented Generation (RAG) tool that provides
 semantic search capabilities over a knowledge graph of climate conference documents stored in
-FalkorDB. It leverages the Graphiti library to perform hybrid search (combining vector similarity
-and keyword matching) over entities and relationships extracted from UNFCCC documents including
-COP, CMA, CMP, SBI, and SBSTA proceedings.
+Neo4j or FalkorDB. It leverages the Graphiti library to perform hybrid search (combining vector
+similarity and keyword matching) over entities and relationships extracted from UNFCCC documents
+including COP, CMA, CMP, SBI, and SBSTA proceedings.
 
 Architecture:
     - Uses Graphiti Core for graph operations and hybrid search
-    - Connects to FalkorDB (Redis-based graph database) for knowledge storage
+    - Automatically detects and connects to Neo4j or FalkorDB based on environment variables
     - Implements singleton pattern for graph connections (shared across invocations)
-    - Supports three search modes: general facts, entities, and relationships
+    - Supports four search modes: general facts, entities, relationships, and episodes
     - Automatically enriches results with connected nodes and relationships
+
+Database Detection:
+    - If NEO4J_URI is set, uses Neo4j
+    - If FALKORDB_HOST is set (and NEO4J_URI is not), uses FalkorDB
+    - Priority: Neo4j > FalkorDB
 
 Search Types:
     1. "general" (default): Searches for general facts and relationships in the graph.
@@ -34,6 +39,10 @@ Search Types:
 
     3. "relationship": Searches for relationship edges between entities.
        Returns relationships with source and target entity details.
+
+    4. "episode": Searches for primary source document content (episodes).
+       Returns original document text with metadata (conference, year, decision IDs).
+       Best for getting exact wording from source documents.
 """
 import os
 import traceback
@@ -52,19 +61,24 @@ load_dotenv(dotenv_path=_current_dir / ".env")
 
 from graphiti_core import Graphiti
 from graphiti_core.driver.falkordb_driver import FalkorDriver
+from graphiti_core.driver.neo4j_driver import Neo4jDriver
 
 
 class GraphSearchTool(CodedTool):
     """
     Graph-based RAG tool for semantic search over UNFCCC climate documents.
 
-    Performs hybrid search (vector + keyword) over knowledge graph stored in FalkorDB.
-    Supports three search modes: general facts, entities, and relationships.
+    Performs hybrid search (vector + keyword) over knowledge graph stored in Neo4j or FalkorDB.
+    Supports four search modes: general facts, entities, relationships, and episodes.
+    Automatically detects which database to use based on environment variables.
     """
 
     # Class-level instances shared across all invocations
     _graphiti_instance: Optional[Graphiti] = None
-    _driver_instance: Optional[FalkorDriver] = None
+    _driver_instance: Optional[Any] = None  # Can be Neo4jDriver or FalkorDriver
+    _db_type: Optional[str] = None  # Track which database we're using
+    # Max output size in characters (~10K tokens) to stay within GPT-4o context
+    MAX_OUTPUT_CHARS = 40000
 
     async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> str:
         """
@@ -79,51 +93,731 @@ class GraphSearchTool(CodedTool):
             if GraphSearchTool._graphiti_instance is None:
                 await self._initialize_graph()
 
+            # Validate connection
+            if GraphSearchTool._graphiti_instance is None or GraphSearchTool._driver_instance is None:
+                return (
+                    "Error: Failed to initialize graph connection.\n"
+                    "\n"
+                    "This tool supports both Neo4j and FalkorDB. Please configure ONE of:\n"
+                    "\n"
+                    "Option 1 - Neo4j (Recommended):\n"
+                    "  Set these in your .env file:\n"
+                    "  - NEO4J_URI (e.g., bolt://localhost:7687 or neo4j+s://xxx.databases.neo4j.io)\n"
+                    "  - NEO4J_USER (e.g., neo4j)\n"
+                    "  - NEO4J_PASSWORD\n"
+                    "\n"
+                    "Option 2 - FalkorDB:\n"
+                    "  Set these in your .env file:\n"
+                    "  - FALKORDB_HOST (default: localhost)\n"
+                    "  - FALKORDB_PORT (default: 6379)\n"
+                    "  - GRAPH_NAME (default: unfccc_knowledge_graph)\n"
+                    "\n"
+                    "Make sure your chosen database is running and accessible."
+                )
+
             # Extract and validate arguments
             query: str = args.get("query")
             if not query:
                 return "Error: query parameter is required"
 
-            # Convert string inputs to appropriate types
-            limit: int = int(args.get("limit", 10))
-            search_type: str = args.get("search_type", "general")
+            # Get query complexity to determine search depth
+            query_complexity: str = args.get("query_complexity", "medium")
+            valid_complexities = ["direct", "medium", "extensive"]
+            if query_complexity not in valid_complexities:
+                query_complexity = "medium"  # Default to medium if invalid
 
-            # Perform search based on type
-            if search_type == "entity":
+            # Adjust limits based on query complexity
+            complexity_limits = {
+                "direct": 1,      # Minimal: 1 result for specific questions
+                "medium": 5,      # Balanced: 5 results for moderate topics
+                "extensive": 15   # Comprehensive: 15 results for broad exploration
+            }
+
+            # Convert string inputs to appropriate types
+            try:
+                # Use complexity-based default if limit not specified
+                default_limit = complexity_limits.get(query_complexity, 5)
+                limit: int = int(args.get("limit", default_limit))
+            except (ValueError, TypeError):
+                return f"Error: limit must be a valid integer, got: {args.get('limit')}"
+
+            search_type: str = args.get("search_type", "general")
+            valid_types = ["general", "entity", "relationship", "episode"]
+            if search_type not in valid_types:
+                return f"Error: search_type must be one of {valid_types}, got: {search_type}"
+
+            print(f"Query complexity: {query_complexity}, Limit: {limit}")
+
+            # **ENHANCED SEARCH QUALITY**: Analyze query and determine optimal search strategy
+            query_analysis = self._analyze_query(query)
+            print(f"Query analysis: intent={query_analysis['intent']}, key_concepts={query_analysis['key_concepts']}, decision_id={query_analysis.get('decision_id')}, paragraph_refs={query_analysis.get('paragraph_refs', [])}, temporal_direction={query_analysis.get('temporal_direction')}, is_timeline={query_analysis.get('is_timeline_query')}, is_identification={query_analysis.get('is_identification_query')}, conference_filter={query_analysis.get('conference_filter')}")
+
+            # If user didn't specify search_type, auto-select based on query intent
+            if args.get("search_type") is None:
+                search_type = query_analysis["recommended_search_type"]
+                print(f"Auto-selected search_type: {search_type}")
+
+            # **ENHANCED SEARCH QUALITY**: Use multi-stage search for ALL general queries.
+            # Multi-stage search produces strictly better results by combining episodes
+            # (primary source documents), entities, AND relationships — whereas single-stage
+            # only returns abstract facts without source document context.
+            # Only use single-stage for explicitly requested non-general search types.
+            if search_type == "general":
+                results, formatted_output = await self._multi_stage_search(query, query_analysis, limit)
+            elif search_type == "entity":
                 results: List[Any] = await self._search_entities(query, limit)
                 formatted_output: str = await self._format_entities(query, results)
             elif search_type == "relationship":
                 results = await self._search_relationships(query, limit)
                 formatted_output = await self._format_relationships(query, results)
+            elif search_type == "episode":
+                results = await self._search_episodes(query, limit)
+                formatted_output = await self._format_episodes(query, results)
             else:
                 results = await self._search_graph(query, limit)
                 formatted_output = await self._format_facts(query, results)
 
             return formatted_output
 
+        except ConnectionError as conn_error:
+            db_name = GraphSearchTool._db_type or "graph database"
+            error_msg: str = (
+                f"Connection error: {str(conn_error)}\n"
+                f"Please verify {db_name} is running and connection settings are correct."
+            )
+            traceback.print_exc()
+            return error_msg
+        except TimeoutError as timeout_error:
+            error_msg: str = (
+                f"Timeout error: {str(timeout_error)}\n"
+                "The search query took too long. Try a more specific query or reduce the limit."
+            )
+            traceback.print_exc()
+            return error_msg
         # pylint: disable=broad-exception-caught
         except Exception as exception:
-            error_msg: str = f"Error executing graph search: {str(exception)}"
+            error_msg: str = (
+                f"Unexpected error during graph search:\n"
+                f"  Error type: {type(exception).__name__}\n"
+                f"  Error message: {str(exception)}\n"
+                f"  Query: {args.get('query', 'N/A')}\n"
+                f"  Search type: {args.get('search_type', 'general')}\n"
+                "\nPlease check the traceback above for more details."
+            )
             traceback.print_exc()
             return error_msg
 
+    def _analyze_query(self, query: str) -> Dict[str, Any]:
+        """
+        Analyze the query to extract key information and determine optimal search strategy.
+
+        Identifies:
+        - Query intent (factual, requirement, definition, relationship)
+        - Key concepts and entities
+        - Temporal markers (years, conferences)
+        - Structural markers (annex, decision, article)
+        - Complexity level
+        - Recommended search approach
+
+        :param query: User's search query
+        :return: Dictionary with query analysis results
+        """
+        query_lower = query.lower()
+        analysis = {
+            "intent": "factual",  # factual, requirement, definition, relationship
+            "key_concepts": [],
+            "temporal_markers": [],
+            "structural_markers": [],
+            "complexity": "medium",  # low, medium, high
+            "recommended_search_type": "general",
+            "query_type": "medium_context",  # direct, medium_context, extensive_context
+        }
+
+        # Detect intent signals
+        if any(word in query_lower for word in ["what condition", "must", "require", "obligation", "shall"]):
+            analysis["intent"] = "requirement"
+        elif any(word in query_lower for word in ["what is", "define", "definition", "meaning of"]):
+            analysis["intent"] = "definition"
+        elif any(word in query_lower for word in ["relationship", "connect", "relate", "between", "link"]):
+            analysis["intent"] = "relationship"
+
+        # Extract UNFCCC-specific concepts
+        unfccc_concepts = [
+            "mitigation", "adaptation", "co-benefits", "NDC", "nationally determined contribution",
+            "transparency", "reporting", "review", "compliance", "finance", "technology transfer",
+            "capacity building", "loss and damage", "market mechanism", "Article 6",
+            "global stocktake", "enhanced transparency framework", "ETF", "biennial transparency report",
+            "BTR", "nationally appropriate mitigation action", "NAMA", "adaptation communication",
+            "economic diversification", "just transition", "common timeframes", "IPCC",
+            "developed country", "developing country", "least developed country", "LDC",
+            "small island developing state", "SIDS", "Party", "Parties"
+        ]
+        for concept in unfccc_concepts:
+            if concept in query_lower:
+                analysis["key_concepts"].append(concept)
+
+        # Extract temporal markers
+        import re
+        years = re.findall(r'\b(19\d{2}|20\d{2})\b', query)
+        analysis["temporal_markers"].extend(years)
+
+        conference_types = ["COP", "CMA", "CMP", "SBI", "SBSTA"]
+        for conf in conference_types:
+            if conf.lower() in query_lower:
+                analysis["temporal_markers"].append(conf)
+
+        # Extract conference type constraint for filtering results
+        # If user says "CMA decision" or "across CMA sessions", only return CMA results
+        # Also handle "CP" as alias for "COP"
+        conference_filter = None
+        # Check for explicit conference constraints (order matters: check longer patterns first)
+        conf_constraint_patterns = [
+            (r'\bcma\s+(?:decision|session)', "CMA"),
+            (r'\bcop\s+(?:decision|session)', "COP"),
+            (r'\bcp\s+(?:decision|session)', "COP"),
+            (r'\bcmp\s+(?:decision|session)', "CMP"),
+            (r'\bsbi\s+(?:decision|session|report)', "SBI"),
+            (r'\bsbsta\s+(?:decision|session|report)', "SBSTA"),
+            (r'\bacross\s+(?:\w+\s+)?cma\b', "CMA"),
+            (r'\bacross\s+(?:\w+\s+)?cop\b', "COP"),
+            (r'\bacross\s+(?:\w+\s+)?cmp\b', "CMP"),
+            (r'\ba\s+(?:later\s+)?cma\b', "CMA"),
+            (r'\ba\s+(?:later\s+)?cop\b', "COP"),
+            (r'\ba\s+(?:later\s+)?cmp\b', "CMP"),
+            (r'\bwhich\s+cma\b', "CMA"),
+            (r'\bwhich\s+cop\b', "COP"),
+            (r'\bwhich\s+cmp\b', "CMP"),
+        ]
+        for pattern, conf_type in conf_constraint_patterns:
+            if re.search(pattern, query_lower):
+                conference_filter = conf_type
+                break
+        # Fallback: if only one conference type is mentioned in the query, use it as filter
+        if not conference_filter:
+            mentioned_confs = [c for c in conference_types if c.lower() in query_lower]
+            # Also check for "cp" as alias for COP
+            if "cp" in query_lower.split() and "COP" not in mentioned_confs:
+                mentioned_confs.append("COP")
+            if len(mentioned_confs) == 1:
+                conference_filter = mentioned_confs[0]
+        analysis["conference_filter"] = conference_filter
+
+        # Extract structural markers (document structure references)
+        structural_terms = {
+            "annex": r'\bannex(?:es)?\s*[IVX\d]*\b',
+            "decision": r'\bdecision\s*\d+/[A-Z]+\.\d+\b',
+            "article": r'\barticle\s*\d+\b',
+            "paragraph": r'\bparagraph\s*\d+\b',
+            "section": r'\bsection\s*[IVX\d]+\b'
+        }
+        for term, pattern in structural_terms.items():
+            if re.search(pattern, query_lower):
+                analysis["structural_markers"].append(term)
+
+        # Extract specific decision references (e.g., "Decision 3/CMA.1")
+        decision_pattern = r'\bdecision\s+(\d+/[A-Z]+\.\d+)\b'
+        decision_match = re.search(decision_pattern, query_lower, re.IGNORECASE)
+        if decision_match:
+            analysis["decision_id"] = decision_match.group(1).upper()
+        else:
+            analysis["decision_id"] = None
+
+        # Extract specific paragraph references (e.g., "para 123", "paragraph 121(m)(i-iv)")
+        paragraph_patterns = [
+            r'\b(?:para\.?|paragraph)\s+(\d+)(?:\s*\(([a-z])\))?(?:\s*\(([ivxlc]+)\))?',
+            r'\(para\.?\s*(\d+)(?:\s*\(([a-z])\))?(?:\s*\(([ivxlc]+)\))?\)',
+        ]
+        analysis["paragraph_refs"] = []
+        for pattern in paragraph_patterns:
+            matches = re.finditer(pattern, query_lower, re.IGNORECASE)
+            for match in matches:
+                para_ref = {
+                    "number": match.group(1),
+                    "subsection": match.group(2) if match.lastindex >= 2 else None,
+                    "subsubsection": match.group(3) if match.lastindex >= 3 else None,
+                }
+                analysis["paragraph_refs"].append(para_ref)
+
+        # Detect chronological/temporal direction queries
+        chronological_earliest = [
+            "first", "originally", "initially", "created", "creates",
+            "established", "establishes", "founded", "founds",
+            "inception", "origin", "earliest", "when was",
+            "who created", "who established", "which decision created",
+            "which decision established", "which decision creates",
+            "set up", "sets up", "launched", "launches",
+        ]
+        chronological_latest = [
+            "latest", "most recent", "current", "last updated", "newest",
+        ]
+        # Detect timeline/evolution queries (all decisions on a topic)
+        timeline_markers = [
+            "all decisions", "every decision", "timeline", "evolution",
+            "history of", "how did", "what decisions were made",
+            "what decisions address", "complete history",
+            "chronolog", "over time", "across sessions", "track",
+            "follow-up", "follow up", "review timing", "review cycle",
+            "reporting cycle", "subsequent", "later sessions",
+            "multiple sessions", "across multiple", "governance",
+        ]
+        # Detect identification queries (user describes a decision by content, not by ID)
+        # e.g., "A later CMA decision creates a new network to support developing countries"
+        identification_markers = [
+            "a decision", "a later decision", "a cma decision", "a cop decision",
+            "a cmp decision", "the decision that", "which decision",
+            "which cma decision", "which cop decision", "which cmp decision",
+            "identify the decision", "find the decision",
+            "a later cma", "a later cop", "a later cmp",
+        ]
+        is_identification = any(
+            marker in query_lower for marker in identification_markers
+        )
+        # Also detect descriptive patterns: "[conference] decision [verb]s..."
+        if not is_identification and re.search(
+            r'\b(?:cma|cop|cmp|cp)\s+decision\s+\w+s\b', query_lower
+        ):
+            is_identification = True
+        # Long descriptive queries about what a decision does are likely identification
+        if not is_identification and len(query.split()) > 15 and any(
+            conf.lower() in query_lower for conf in conference_types
+        ):
+            is_identification = True
+
+        analysis["is_identification_query"] = is_identification
+
+        if any(marker in query_lower for marker in chronological_earliest):
+            analysis["temporal_direction"] = "earliest"
+            analysis["follow_references"] = True
+        elif any(marker in query_lower for marker in chronological_latest):
+            analysis["temporal_direction"] = "latest"
+            analysis["follow_references"] = False
+        else:
+            analysis["temporal_direction"] = None
+            analysis["follow_references"] = False
+
+        analysis["is_timeline_query"] = any(
+            marker in query_lower for marker in timeline_markers
+        )
+
+        # Detect multi-stage governance evolution queries
+        # When a query describes multiple governance phases, treat as timeline query
+        # e.g., "creates a body... and also sets out follow-up actions... and future review timing"
+        governance_phase_markers = [
+            "establishes", "creates", "set up", "sets up",  # Phase 1: creation
+            "follow-up", "follow up", "operationalize",     # Phase 2: operationalization
+            "review", "reporting", "integration", "mandate", # Phase 3: review/integration
+            "recommendations", "workplan", "work plan",
+            "annual report", "midterm review",
+        ]
+        phase_count = sum(1 for m in governance_phase_markers if m in query_lower)
+        if phase_count >= 2 and not analysis["is_timeline_query"]:
+            analysis["is_timeline_query"] = True
+            print(f"Multi-stage governance query detected ({phase_count} phases mentioned)")
+
+        # Also trigger timeline for identification queries that mention multiple actions
+        # e.g., "creates a network AND sets out follow-up actions AND future review timing"
+        has_multiple_actions = query_lower.count(" and ") >= 2 or query_lower.count("also") >= 1
+        if has_multiple_actions and analysis.get("is_identification_query") and not analysis["is_timeline_query"]:
+            analysis["is_timeline_query"] = True
+            print("Multi-action identification query detected, enabling timeline search")
+
+        # Determine complexity
+        complexity_score = 0
+        complexity_score += len(analysis["key_concepts"])
+        complexity_score += 2 if analysis["structural_markers"] else 0
+        complexity_score += 2 if analysis["intent"] == "requirement" else 0
+        complexity_score += 1 if len(query.split()) > 15 else 0
+
+        if complexity_score >= 5:
+            analysis["complexity"] = "high"
+        elif complexity_score <= 2:
+            analysis["complexity"] = "low"
+
+        # Force high complexity for temporal/timeline/identification queries
+        if analysis.get("temporal_direction") or analysis.get("is_timeline_query") or analysis.get("is_identification_query"):
+            analysis["complexity"] = "high"
+
+        # Recommend search type based on analysis
+        if analysis["intent"] == "requirement" and analysis["structural_markers"]:
+            # Questions about specific requirements in document structure need primary sources
+            analysis["recommended_search_type"] = "episode"
+        elif analysis["intent"] == "relationship":
+            analysis["recommended_search_type"] = "relationship"
+        elif analysis["intent"] == "definition" and len(analysis["key_concepts"]) == 1:
+            analysis["recommended_search_type"] = "entity"
+        else:
+            analysis["recommended_search_type"] = "general"
+
+        return analysis
+
+    async def _multi_stage_search(
+        self, query: str, query_analysis: Dict[str, Any], limit: int
+    ) -> tuple:
+        """
+        Perform multi-stage search for complex queries requiring comprehensive answers.
+
+        Strategy:
+        1. Search for relevant entities to understand key concepts
+        2. Search episodes (primary sources) for exact document text
+        3. Search relationships to understand connections
+        4. Merge and synthesize results
+
+        :param query: Original search query
+        :param query_analysis: Analysis results from _analyze_query
+        :param limit: Maximum results per stage
+        :return: Tuple of (combined_results, formatted_output)
+        """
+        print(f"Executing multi-stage search for complex query: {query[:80]}...")
+
+        # PRIORITY 0: If specific decision is referenced, search for it directly
+        decision_results = []
+        if query_analysis.get("decision_id"):
+            print(f"Detected specific decision reference: {query_analysis['decision_id']}, searching directly...")
+            decision_results = await self._search_by_decision(query_analysis["decision_id"], query)
+
+        # PRIORITY 1: If specific paragraphs are referenced, try paragraph-based search
+        paragraph_results = []
+        if query_analysis.get("paragraph_refs"):
+            print(f"Detected {len(query_analysis['paragraph_refs'])} paragraph reference(s), attempting metadata search...")
+            paragraph_results = await self._search_by_paragraph(query, query_analysis)
+
+            # If we found specific paragraphs, prioritize those and do lighter follow-up searches
+            if paragraph_results:
+                print(f"Found {len(paragraph_results)} paragraphs via metadata search")
+                # Still do entity/relationship search but with lower limits
+                entity_limit = max(2, limit // 4)
+                episode_limit = 0  # Skip general episode search since we have specific paragraphs
+            else:
+                print("Paragraph metadata search found nothing, falling back to standard search")
+                entity_limit = max(3, limit // 3)
+                episode_limit = max(5, limit // 2)
+        else:
+            # Normal search limits
+            entity_limit = max(3, limit // 3)
+            episode_limit = max(5, limit // 2)
+
+        # Boost episode limit for timeline/evolution queries (need comprehensive results)
+        if query_analysis.get("is_timeline_query") or (
+            query_analysis.get("is_identification_query") and query_analysis.get("temporal_direction")
+        ):
+            episode_limit = max(episode_limit, 15)
+            print(f"Boosted episode limit to {episode_limit} for timeline/evolution query")
+
+        # Stage 1: Find relevant entities (reduced limit for speed)
+        print(f"Stage 1: Searching entities (limit={entity_limit})")
+        entity_results = await self._search_entities(query, entity_limit)
+
+        # Stage 2: Search primary source documents (episodes) - THIS IS CRITICAL
+        # (May be skipped if we already found specific paragraphs)
+        episode_results = []
+        if episode_limit > 0:
+            print(f"Stage 2: Searching episodes/documents (limit={episode_limit})")
+
+            # Enhanced query for episode search: add structural markers if detected
+            episode_query = query
+            if query_analysis["structural_markers"]:
+                # Questions about annexes/articles need exact document text
+                structural_terms = " ".join(query_analysis["structural_markers"])
+                episode_query = f"{query} {structural_terms}"
+
+            episode_results = await self._search_episodes(episode_query, episode_limit)
+
+        # Apply conference type filter if specified (e.g., only CMA results when user asks about CMA)
+        conf_filter = query_analysis.get("conference_filter")
+        if conf_filter and episode_results:
+            pre_filter_count = len(episode_results)
+            episode_results = self._filter_by_conference(episode_results, conf_filter)
+            if len(episode_results) < pre_filter_count:
+                print(f"Conference filter '{conf_filter}': {pre_filter_count} → {len(episode_results)} episodes")
+
+        if not episode_results and paragraph_results:
+            print("Stage 2: Skipping general episode search (using paragraph results instead)")
+
+        # Stage 2B: Follow backward references for chronological/creation queries
+        # Run backward refs for BOTH follow_references AND identification queries with creation language
+        referenced_decisions = []
+        should_follow_refs = (
+            query_analysis.get("follow_references")
+            or (query_analysis.get("is_identification_query") and query_analysis.get("temporal_direction") == "earliest")
+        )
+        if should_follow_refs and episode_results:
+            print("Stage 2B: Following backward references for chronological/creation query...")
+            referenced_decisions = await self._follow_backward_references(episode_results)
+            if referenced_decisions:
+                print(f"Found {len(referenced_decisions)} referenced earlier decision(s)")
+
+        # Stage 2C: For timeline queries, search broadly for all decisions on the topic
+        timeline_results = []
+        if query_analysis.get("is_timeline_query"):
+            print("Stage 2C: Searching for complete decision timeline...")
+            timeline_results = await self._search_topic_timeline(query, query_analysis, limit=20)
+            if timeline_results:
+                print(f"Found {len(timeline_results)} decisions for timeline")
+
+        # Temporal re-ranking for chronological queries
+        if query_analysis.get("temporal_direction") and episode_results:
+            episode_results = self._temporal_rerank(episode_results, query_analysis["temporal_direction"])
+            print(f"Re-ranked episodes by {query_analysis['temporal_direction']} year")
+
+        # Stage 2D: Classify episodes as founding/follow-up for creation queries
+        founding_analysis = None
+        is_creation_query = query_analysis.get("temporal_direction") == "earliest" or (
+            query_analysis.get("is_identification_query") and any(
+                w in query.lower() for w in ["creates", "created", "establishes", "established", "set up", "sets up", "launches", "launched", "founded"]
+            )
+        )
+        if is_creation_query and episode_results:
+            founding_analysis = self._classify_episodes_founding(episode_results)
+            print(f"Founding analysis: {founding_analysis['summary']}")
+
+        # Stage 3: Search relationships if relevant
+        relationship_results = []
+        if query_analysis["intent"] == "requirement" or len(entity_results) > 0:
+            rel_limit = max(2, limit // 4)
+            print(f"Stage 3: Searching relationships (limit={rel_limit})")
+            relationship_results = await self._search_relationships(query, rel_limit)
+
+        # Synthesize results with priority on episodes (primary sources)
+        print("Synthesizing multi-stage results...")
+        output_parts = [
+            f"MULTI-STAGE SEARCH RESULTS FOR: '{query}'",
+            f"Query Complexity: {query_analysis['complexity'].upper()}",
+            f"Query Intent: {query_analysis['intent'].upper()}",
+            f"Key Concepts: {', '.join(query_analysis['key_concepts'][:5]) if query_analysis['key_concepts'] else 'None detected'}",
+            f"Conference Filter: {conf_filter if conf_filter else 'None (all conferences)'}",
+            "",
+            "=" * 80,
+            "",
+        ]
+
+        # PRIORITY 0A: Specific decision (HIGHEST PRIORITY for decision queries)
+        if decision_results:
+            output_parts.append("=" * 80)
+            output_parts.append("SPECIFIC DECISION (EXACT MATCH)")
+            output_parts.append(f"Direct result for the decision referenced in your query")
+            output_parts.append("=" * 80)
+            output_parts.append("")
+            output_parts.append(decision_results)
+            output_parts.append("")
+
+        # PRIORITY 0B: Specific paragraphs from metadata (HIGHEST PRIORITY for paragraph queries)
+        if paragraph_results:
+            output_parts.append("=" * 80)
+            output_parts.append("SPECIFIC PARAGRAPHS (EXTRACTED FROM METADATA)")
+            output_parts.append("These are the exact paragraphs referenced in your query")
+            output_parts.append("=" * 80)
+            output_parts.append("")
+            for para_result in paragraph_results:
+                output_parts.append(para_result)
+                output_parts.append("")
+
+        # PRIORITY 0C: FOUNDING DECISION ANALYSIS (for creation queries)
+        # When the query asks about creation/establishment, put founding decisions FIRST
+        if founding_analysis and founding_analysis.get("founding_episodes"):
+            output_parts.append("=" * 80)
+            output_parts.append(">>> FOUNDING DECISION(S) IDENTIFIED <<<")
+            output_parts.append("These decisions contain CREATION language (establishes, creates, sets up).")
+            output_parts.append("Use these to answer 'which decision CREATED/ESTABLISHED X' questions.")
+            output_parts.append("=" * 80)
+            output_parts.append("")
+            founding_text = await self._format_episodes(query, founding_analysis["founding_episodes"])
+            output_parts.append(founding_text)
+            output_parts.append("")
+
+        if founding_analysis and founding_analysis.get("followup_episodes"):
+            output_parts.append("=" * 80)
+            output_parts.append("FOLLOW-UP DECISIONS (these further develop/operationalize, NOT create)")
+            output_parts.append("Do NOT cite these as the 'founding' or 'creation' decision.")
+            output_parts.append("=" * 80)
+            output_parts.append("")
+            followup_text = await self._format_episodes(query, founding_analysis["followup_episodes"])
+            output_parts.append(followup_text)
+            output_parts.append("")
+
+        # PRIORITY 0D: Referenced earlier decisions (backward ref traversal)
+        if referenced_decisions:
+            output_parts.append("=" * 80)
+            if is_creation_query:
+                output_parts.append(">>> EARLIER REFERENCED DECISIONS (POTENTIAL FOUNDING DECISIONS) <<<")
+                output_parts.append("These were recalled/referenced by later decisions.")
+                output_parts.append("CHECK THESE FIRST — the founding decision is often referenced by later follow-ups.")
+            else:
+                output_parts.append("EARLIER REFERENCED DECISIONS (TRACED VIA BACKWARD REFERENCES)")
+                output_parts.append("These were recalled/referenced by the results above")
+            output_parts.append("=" * 80)
+            output_parts.append("")
+            for ref_decision in referenced_decisions:
+                output_parts.append(ref_decision)
+                output_parts.append("")
+
+        # PRIORITY 0E: Complete topic timeline
+        if timeline_results:
+            output_parts.append("=" * 80)
+            output_parts.append("COMPLETE DECISION TIMELINE ON THIS TOPIC")
+            output_parts.append("All decisions found, sorted chronologically (earliest first)")
+            output_parts.append("=" * 80)
+            output_parts.append("")
+            for tl_result in timeline_results:
+                output_parts.append(tl_result)
+                output_parts.append("")
+
+        # PRIORITY 1: Episodes (primary sources with exact text)
+        # Skip if we already showed them in founding analysis
+        if episode_results and not founding_analysis:
+            output_parts.append("=" * 80)
+            output_parts.append("PRIMARY SOURCE DOCUMENTS (HIGHEST PRIORITY)")
+            output_parts.append("These contain the EXACT TEXT from UNFCCC documents")
+            output_parts.append("=" * 80)
+            output_parts.append("")
+            episode_text = await self._format_episodes(query, episode_results)
+            output_parts.append(episode_text)
+            output_parts.append("")
+
+        # PRIORITY 2: Entities (concepts and definitions)
+        if entity_results:
+            output_parts.append("=" * 80)
+            output_parts.append("RELEVANT ENTITIES AND CONCEPTS")
+            output_parts.append("=" * 80)
+            output_parts.append("")
+            entity_text = await self._format_entities(query, entity_results)
+            output_parts.append(entity_text)
+            output_parts.append("")
+
+        # PRIORITY 3: Relationships (connections between concepts)
+        if relationship_results:
+            output_parts.append("=" * 80)
+            output_parts.append("RELATIONSHIPS AND CONNECTIONS")
+            output_parts.append("=" * 80)
+            output_parts.append("")
+            rel_text = await self._format_relationships(query, relationship_results)
+            output_parts.append(rel_text)
+            output_parts.append("")
+
+        if not decision_results and not paragraph_results and not referenced_decisions and not timeline_results and not episode_results and not entity_results and not relationship_results:
+            output_parts.append("No results found across all search stages.")
+            output_parts.append("")
+            output_parts.append("Suggestions:")
+            output_parts.append("- Try broader search terms")
+            output_parts.append("- Check spelling of technical terms")
+            output_parts.append("- Verify the concept exists in UNFCCC documents")
+
+        formatted_output = "\n".join(output_parts)
+
+        # Safety net: if total output is still too large, truncate it
+        if len(formatted_output) > self.MAX_OUTPUT_CHARS:
+            print(f"Multi-stage output too large ({len(formatted_output)} chars). Truncating.")
+            formatted_output = self._truncate_content(formatted_output, self.MAX_OUTPUT_CHARS)
+
+        # Return combined results and formatted output
+        combined_results = {
+            "decision": decision_results,
+            "paragraphs": paragraph_results,
+            "referenced_decisions": referenced_decisions,
+            "timeline": timeline_results,
+            "episodes": episode_results,
+            "entities": entity_results,
+            "relationships": relationship_results,
+        }
+
+        return combined_results, formatted_output
+
     async def _initialize_graph(self) -> None:
         """
-        Initialize FalkorDB connection and Graphiti instance.
+        Initialize Neo4j or FalkorDB connection and Graphiti instance.
+
+        Automatically detects which database to use based on environment variables:
+        - If NEO4J_URI is set, uses Neo4j
+        - Otherwise, if FALKORDB_HOST is set, uses FalkorDB
+        - Falls back to FalkorDB defaults if neither is set
 
         :return: None
+        :raises ConnectionError: If connection fails
         """
-        GraphSearchTool._driver_instance = FalkorDriver(
-            host=os.getenv("FALKORDB_HOST", "localhost"),
-            port=int(os.getenv("FALKORDB_PORT", "6379")),
-            username=os.getenv("FALKORDB_USERNAME"),
-            password=os.getenv("FALKORDB_PASSWORD"),
-            database=os.getenv("GRAPH_NAME", "unfccc_knowledge_graph"),
-        )
+        try:
+            # Check for Neo4j configuration first (priority)
+            neo4j_uri = os.getenv("NEO4J_URI")
+            neo4j_user = os.getenv("NEO4J_USER")
+            neo4j_password = os.getenv("NEO4J_PASSWORD")
 
-        GraphSearchTool._graphiti_instance = Graphiti(
-            graph_driver=GraphSearchTool._driver_instance
-        )
+            if neo4j_uri and neo4j_user and neo4j_password:
+                # Use Neo4j
+                GraphSearchTool._db_type = "neo4j"
+                print(f"Detected Neo4j configuration")
+                print(f"Initializing Neo4j connection to {neo4j_uri}")
+
+                GraphSearchTool._driver_instance = Neo4jDriver(
+                    uri=neo4j_uri,
+                    user=neo4j_user,
+                    password=neo4j_password,
+                )
+
+                GraphSearchTool._graphiti_instance = Graphiti(
+                    graph_driver=GraphSearchTool._driver_instance
+                )
+
+                print("Successfully initialized Neo4j graph connection")
+
+            else:
+                # Use FalkorDB
+                GraphSearchTool._db_type = "falkordb"
+                host = os.getenv("FALKORDB_HOST", "localhost")
+                port_str = os.getenv("FALKORDB_PORT", "6379")
+
+                # Validate port is a valid integer
+                try:
+                    port = int(port_str)
+                except (ValueError, TypeError):
+                    raise ValueError(f"FALKORDB_PORT must be a valid integer, got: {port_str}")
+
+                username = os.getenv("FALKORDB_USERNAME")
+                password = os.getenv("FALKORDB_PASSWORD")
+                database = os.getenv("GRAPH_NAME", "unfccc_knowledge_graph")
+
+                print(f"Detected FalkorDB configuration (or using defaults)")
+                print(f"Initializing FalkorDB connection to {host}:{port}, database: {database}")
+
+                GraphSearchTool._driver_instance = FalkorDriver(
+                    host=host,
+                    port=port,
+                    username=username,
+                    password=password,
+                    database=database,
+                )
+
+                GraphSearchTool._graphiti_instance = Graphiti(
+                    graph_driver=GraphSearchTool._driver_instance
+                )
+
+                print("Successfully initialized FalkorDB graph connection")
+
+        except Exception as e:
+            # Provide detailed error message based on which DB we tried to connect to
+            if GraphSearchTool._db_type == "neo4j":
+                error_msg = (
+                    f"Failed to initialize Neo4j connection: {str(e)}\n"
+                    f"Connection details:\n"
+                    f"  URI: {os.getenv('NEO4J_URI', 'NOT SET')}\n"
+                    f"  User: {os.getenv('NEO4J_USER', 'NOT SET')}\n"
+                    "Please verify:\n"
+                    "  1. Neo4j is running and accessible\n"
+                    "  2. NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD are correctly set in .env\n"
+                    "  3. Network connectivity to Neo4j server"
+                )
+            else:
+                error_msg = (
+                    f"Failed to initialize FalkorDB connection: {str(e)}\n"
+                    f"Connection details:\n"
+                    f"  Host: {os.getenv('FALKORDB_HOST', 'localhost')}\n"
+                    f"  Port: {os.getenv('FALKORDB_PORT', '6379')}\n"
+                    f"  Database: {os.getenv('GRAPH_NAME', 'unfccc_knowledge_graph')}\n"
+                    "Please verify:\n"
+                    "  1. FalkorDB is running and accessible\n"
+                    "  2. FALKORDB_HOST, FALKORDB_PORT are correctly set in .env\n"
+                    "  3. Network connectivity to FalkorDB server"
+                )
+
+            print(error_msg)
+            raise ConnectionError(error_msg) from e
 
     async def _search_graph(self, query: str, limit: int) -> List[Any]:
         """
@@ -132,11 +826,19 @@ class GraphSearchTool(CodedTool):
         :param query: Search query text
         :param limit: Maximum number of results
         :return: List of search results
+        :raises: Exception if search fails
         """
-        results = await GraphSearchTool._graphiti_instance.search(
-            query=query, num_results=limit
-        )
-        return results or []
+        try:
+            print(f"Searching graph: query='{query[:50]}...', limit={limit}")
+            results = await GraphSearchTool._graphiti_instance.search(
+                query=query, num_results=limit
+            )
+            result_count = len(results) if results else 0
+            print(f"Graph search returned {result_count} results")
+            return results or []
+        except Exception as e:
+            print(f"Error during graph search: {e}")
+            raise
 
     async def _search_entities(self, query: str, limit: int) -> List[Any]:
         """
@@ -145,18 +847,26 @@ class GraphSearchTool(CodedTool):
         :param query: Search query text
         :param limit: Maximum number of results
         :return: List of entity nodes
+        :raises: Exception if search fails
         """
-        from graphiti_core.search.search_config_recipes import \
-            NODE_HYBRID_SEARCH_RRF
+        try:
+            from graphiti_core.search.search_config_recipes import \
+                NODE_HYBRID_SEARCH_RRF
 
-        config = NODE_HYBRID_SEARCH_RRF.model_copy(deep=True)
-        config.limit = limit
+            print(f"Searching entities: query='{query[:50]}...', limit={limit}")
+            config = NODE_HYBRID_SEARCH_RRF.model_copy(deep=True)
+            config.limit = limit
 
-        results = await GraphSearchTool._graphiti_instance._search(
-            query=query, config=config
-        )
+            results = await GraphSearchTool._graphiti_instance._search(
+                query=query, config=config
+            )
 
-        return results.nodes if results and results.nodes else []
+            node_count = len(results.nodes) if results and results.nodes else 0
+            print(f"Entity search returned {node_count} nodes")
+            return results.nodes if results and results.nodes else []
+        except Exception as e:
+            print(f"Error during entity search: {e}")
+            raise
 
     async def _search_relationships(self, query: str, limit: int) -> List[Any]:
         """
@@ -165,22 +875,727 @@ class GraphSearchTool(CodedTool):
         :param query: Search query text
         :param limit: Maximum number of results
         :return: List of relationship edges
+        :raises: Exception if search fails
         """
-        from graphiti_core.search.search_config_recipes import \
-            EDGE_HYBRID_SEARCH_RRF
+        try:
+            from graphiti_core.search.search_config_recipes import \
+                EDGE_HYBRID_SEARCH_RRF
 
-        config = EDGE_HYBRID_SEARCH_RRF.model_copy(deep=True)
-        config.limit = limit
+            print(f"Searching relationships: query='{query[:50]}...', limit={limit}")
+            config = EDGE_HYBRID_SEARCH_RRF.model_copy(deep=True)
+            config.limit = limit
 
-        results = await GraphSearchTool._graphiti_instance._search(
-            query=query, config=config
+            results = await GraphSearchTool._graphiti_instance._search(
+                query=query, config=config
+            )
+
+            edge_count = len(results.edges) if results and results.edges else 0
+            print(f"Relationship search returned {edge_count} edges")
+            return results.edges if results and results.edges else []
+        except Exception as e:
+            print(f"Error during relationship search: {e}")
+            raise
+
+    async def _search_episodes(self, query: str, limit: int) -> List[Any]:
+        """
+        Search for episode nodes (primary source documents) in the graph.
+
+        Episodes contain the original document text and metadata, providing
+        direct access to primary information from UNFCCC documents.
+
+        **ENHANCED**: Expands query with UNFCCC terminology and synonyms for better retrieval.
+
+        :param query: Search query text
+        :param limit: Maximum number of results
+        :return: List of episode nodes
+        :raises: Exception if search fails
+        """
+        try:
+            from graphiti_core.search.search_config_recipes import (
+                COMBINED_HYBRID_SEARCH_RRF
+            )
+
+            # **ENHANCED SEARCH QUALITY**: Expand query with UNFCCC-specific terminology
+            expanded_query = self._expand_query_terms(query)
+            print(f"Searching episodes: original='{query[:50]}...', expanded='{expanded_query[:70]}...'")
+
+            # Use combined search config (searches all types, including episodes)
+            config = COMBINED_HYBRID_SEARCH_RRF.model_copy(deep=True)
+            config.limit = limit
+
+            results = await GraphSearchTool._graphiti_instance._search(
+                query=expanded_query, config=config
+            )
+
+            episode_count = len(results.episodes) if results and results.episodes else 0
+            print(f"Episode search returned {episode_count} episodes")
+            return results.episodes if results and results.episodes else []
+        except Exception as e:
+            print(f"Error during episode search: {e}")
+            raise
+
+    async def _search_by_decision(self, decision_id: str, query: str) -> str:
+        """
+        Search for a specific decision by its ID in episode metadata.
+
+        Uses two strategies:
+        1. Semantic search + metadata matching (fast but may miss some)
+        2. Direct Cypher query on episode names/content (fallback, more reliable)
+
+        :param decision_id: Decision ID (e.g., "3/CMA.1", "17/CP.22")
+        :param query: Original query for context
+        :return: Formatted decision text or empty string if not found
+        """
+        try:
+            from graphiti_core.search.search_config_recipes import (
+                COMBINED_HYBRID_SEARCH_RRF
+            )
+
+            # Strategy 1: Semantic search + metadata matching
+            search_query = f"decision {decision_id}"
+            print(f"Searching for decision: {decision_id}")
+
+            config = COMBINED_HYBRID_SEARCH_RRF.model_copy(deep=True)
+            config.limit = 10
+
+            search_results = await GraphSearchTool._graphiti_instance._search(
+                query=search_query, config=config
+            )
+
+            episodes = search_results.episodes if search_results and search_results.episodes else []
+            print(f"Found {len(episodes)} candidate episodes via semantic search")
+
+            # Check metadata for exact decision_id match
+            for episode in episodes:
+                if not hasattr(episode, 'metadata') or not episode.metadata:
+                    continue
+
+                episode_decision_id = episode.metadata.get("decision_id", "")
+                if episode_decision_id and episode_decision_id.strip().upper() == decision_id.strip().upper():
+                    print(f"Found exact match via semantic search: {episode.name if hasattr(episode, 'name') else 'Unknown'}")
+                    return self._format_decision_result(decision_id, episode)
+
+            # Strategy 2: Direct Cypher query as fallback
+            print(f"Semantic search didn't find Decision {decision_id}, trying direct database query...")
+            direct_result = await self._search_decision_by_cypher(decision_id)
+            if direct_result:
+                return direct_result
+
+            print(f"WARNING: Decision {decision_id} not found by any method")
+            return ""
+
+        except Exception as e:
+            print(f"Error during decision search: {e}")
+            import traceback
+            traceback.print_exc()
+            return ""
+
+    def _format_decision_result(self, decision_id: str, episode) -> str:
+        """Format a found decision episode into a readable result."""
+        episode_content = episode.content if hasattr(episode, 'content') else str(episode)
+        metadata = episode.metadata if hasattr(episode, 'metadata') and episode.metadata else {}
+
+        conference = metadata.get("conference_name", "Unknown")
+        year = metadata.get("year", "Unknown")
+        location = metadata.get("location", "Unknown")
+
+        action_type = metadata.get("decision_action_type", "")
+        action_label = f" [{action_type.upper()}]" if action_type else ""
+
+        formatted_result = f">>> DECISION {decision_id} ({year}){action_label} <<<\n"
+        formatted_result += f"Conference: {conference}\n"
+        formatted_result += f"Year: {year}, Location: {location}\n"
+        formatted_result += f"\nEXACT TEXT FROM SOURCE:\n"
+        formatted_result += "-" * 80 + "\n"
+        formatted_result += f"{episode_content}\n"
+
+        return formatted_result
+
+    async def _search_decision_by_cypher(self, decision_id: str) -> str:
+        """
+        Search for a decision directly in the database using Cypher query.
+
+        Searches episode names and content for the decision ID string.
+        This is a reliable fallback when semantic search misses the episode.
+
+        :param decision_id: Decision ID (e.g., "17/CP.22")
+        :return: Formatted result or empty string
+        """
+        if not GraphSearchTool._driver_instance:
+            return ""
+
+        try:
+            # Normalize: try both with and without spaces around /
+            decision_id_clean = decision_id.strip().upper()
+            # Search by episode name containing the decision ID
+            cypher_query = """
+            MATCH (e:Episodic)
+            WHERE toUpper(e.name) CONTAINS $decision_id
+               OR toUpper(e.content) CONTAINS $search_term
+            RETURN e.name as name, e.content as content, e.source_description as source_description
+            LIMIT 1
+            """
+            search_term = f"DECISION {decision_id_clean}"
+            print(f"Direct Cypher query for: {search_term}")
+
+            records, _, _ = await GraphSearchTool._driver_instance.execute_query(
+                cypher_query,
+                decision_id=decision_id_clean,
+                search_term=search_term,
+            )
+
+            if records:
+                record = dict(records[0])
+                content = record.get("content", "")
+                name = record.get("name", "Unknown")
+                source_desc = record.get("source_description", "")
+
+                print(f"Found decision via direct Cypher: {name}")
+
+                formatted_result = f">>> DECISION {decision_id} <<<\n"
+                formatted_result += f"Source: {source_desc or name}\n"
+                formatted_result += f"\nEXACT TEXT FROM SOURCE:\n"
+                formatted_result += "-" * 80 + "\n"
+                formatted_result += f"{content}\n"
+
+                return formatted_result
+
+            print(f"Direct Cypher query found no results for Decision {decision_id}")
+            return ""
+
+        except Exception as e:
+            print(f"Error during direct Cypher search: {e}")
+            import traceback
+            traceback.print_exc()
+            return ""
+
+    async def _search_by_paragraph(
+        self, query: str, query_analysis: Dict[str, Any]
+    ) -> List[str]:
+        """
+        Search for specific paragraphs using metadata paragraph_index.
+
+        This method extracts paragraph references from the query, searches for
+        episodes containing those paragraphs, and returns the exact paragraph text
+        from the metadata.
+
+        :param query: Original search query
+        :param query_analysis: Analysis results containing paragraph_refs
+        :return: List of formatted paragraph results
+        """
+        import re
+
+        paragraph_refs = query_analysis.get("paragraph_refs", [])
+        if not paragraph_refs:
+            return []
+
+        results = []
+
+        # Extract decision reference from query (e.g., "Decision 4/CMA.1")
+        decision_pattern = r'\b(?:decision|resolution)\s+(\d+/[A-Z]+\.\d+)\b'
+        decision_match = re.search(decision_pattern, query, re.IGNORECASE)
+        decision_id = decision_match.group(1) if decision_match else None
+
+        # Try to find episodes that might contain these paragraphs
+        # Strategy: search for decision ID or use broader search
+        if decision_id:
+            search_query = f"decision {decision_id}"
+        else:
+            # Extract key terms from query for broader search
+            search_query = query[:100]
+
+        print(f"Searching for episodes containing decision: {decision_id or 'unknown (using query)'}")
+
+        try:
+            from graphiti_core.search.search_config_recipes import (
+                COMBINED_HYBRID_SEARCH_RRF
+            )
+
+            # Use combined search to find episodes
+            config = COMBINED_HYBRID_SEARCH_RRF.model_copy(deep=True)
+            config.limit = 10  # Get more candidates to find the right decision
+
+            search_results = await GraphSearchTool._graphiti_instance._search(
+                query=search_query, config=config
+            )
+
+            episodes = search_results.episodes if search_results and search_results.episodes else []
+            print(f"Found {len(episodes)} candidate episodes to search for paragraphs")
+
+            # Extract paragraphs from episode metadata
+            for para_ref in paragraph_refs:
+                para_num = para_ref["number"]
+                subsection = para_ref.get("subsection")
+                subsubsection = para_ref.get("subsubsection")
+
+                # Build paragraph identifier
+                para_id = para_num
+                if subsection:
+                    para_id += f"({subsection})"
+                if subsubsection:
+                    para_id += f"({subsubsection})"
+
+                found = False
+                for episode in episodes:
+                    # Check if episode has paragraph_index in metadata
+                    if not hasattr(episode, 'metadata') or not episode.metadata:
+                        continue
+
+                    paragraph_index = episode.metadata.get("paragraph_index", {})
+                    if not paragraph_index:
+                        continue
+
+                    # Try to find the paragraph in the index
+                    para_text = None
+                    if para_num in paragraph_index:
+                        para_text = paragraph_index[para_num]
+                    elif str(para_num) in paragraph_index:
+                        para_text = paragraph_index[str(para_num)]
+
+                    if para_text:
+                        # Format the result
+                        episode_name = episode.name if hasattr(episode, 'name') else 'Unknown'
+                        decision_from_metadata = episode.metadata.get("decision_id", "Unknown")
+
+                        formatted_result = f"**Paragraph {para_id}** from {decision_from_metadata}\n"
+                        formatted_result += f"Source: {episode_name}\n"
+                        formatted_result += f"\n{para_text}\n"
+
+                        results.append(formatted_result)
+                        found = True
+                        print(f"Found paragraph {para_id} in episode: {episode_name}")
+                        break
+
+                if not found:
+                    print(f"WARNING: Could not find paragraph {para_id} in any episode metadata")
+
+        except Exception as e:
+            print(f"Error during paragraph metadata search: {e}")
+            import traceback
+            traceback.print_exc()
+
+        return results
+
+    @staticmethod
+    def _truncate_content(content: str, max_chars: int = 8000) -> str:
+        """Truncate content to fit within context limits."""
+        if len(content) <= max_chars:
+            return content
+        return content[:max_chars] + "\n\n[... content truncated. Use a more specific query for full text ...]"
+
+    def _expand_query_terms(self, query: str) -> str:
+        """
+        Expand query with UNFCCC synonyms and related terms for better document retrieval.
+
+        Maps common terms to official UNFCCC terminology to improve matching.
+
+        :param query: Original query string
+        :return: Expanded query string with additional terms
+        """
+        query_lower = query.lower()
+        expansions = []
+
+        # UNFCCC terminology mappings
+        term_mappings = {
+            "mitigation co-benefits": ["co-benefits from mitigation", "mitigation benefits", "ancillary benefits"],
+            "adaptation action": ["adaptation activities", "adaptation measures", "adaptation efforts"],
+            "economic diversification": ["diversification plans", "economic transformation", "structural transformation"],
+            "additional information": ["further information", "supplementary information", "more detailed information"],
+            "Party": ["country", "nation", "State Party", "Parties"],
+            "must provide": ["shall provide", "required to provide", "obligation to provide", "provide"],
+            "transparency": ["transparency framework", "ETF", "enhanced transparency framework"],
+            "reporting": ["report", "BTR", "biennial transparency report", "national communication"],
+            "NDC": ["nationally determined contribution", "nationally determined contributions"],
+            "annex": ["annexes", "appendix", "attachment"],
+            "decision": ["decisions", "decision document"],
+        }
+
+        # Add expansion terms if key phrases are found
+        for key_phrase, synonyms in term_mappings.items():
+            if key_phrase in query_lower:
+                # Add the most relevant synonyms (limit to avoid over-expansion)
+                expansions.extend(synonyms[:2])
+
+        # Combine original query with expansions
+        if expansions:
+            expanded = f"{query} {' '.join(expansions)}"
+            return expanded
+        return query
+
+    def _filter_by_conference(self, results: List[Any], conference_type: str) -> List[Any]:
+        """Filter episode results to only include episodes from the specified conference type.
+
+        Checks episode metadata 'conference_type' and episode name/decision_id for
+        conference type markers (CMA, COP/CP, CMP, SBI, SBSTA).
+
+        :param results: List of episode results to filter
+        :param conference_type: Conference type to filter by (e.g., "CMA", "COP", "CMP")
+        :return: Filtered list of results matching the conference type
+        """
+        import re as re_mod
+
+        # Normalize conference type aliases
+        conf_aliases = {
+            "COP": ["COP", "CP"],
+            "CMA": ["CMA"],
+            "CMP": ["CMP"],
+            "SBI": ["SBI"],
+            "SBSTA": ["SBSTA"],
+        }
+        target_aliases = conf_aliases.get(conference_type, [conference_type])
+
+        filtered = []
+        for episode in results:
+            metadata = getattr(episode, 'metadata', None) or {}
+
+            # Check metadata conference_type field
+            meta_conf = metadata.get('conference_type', '').upper()
+            if meta_conf in target_aliases:
+                filtered.append(episode)
+                continue
+
+            # Check decision_id pattern (e.g., "2/CMA.2" contains "CMA")
+            decision_id = metadata.get('decision_id', '').upper()
+            if any(alias in decision_id for alias in target_aliases):
+                filtered.append(episode)
+                continue
+
+            # Check episode name for conference type
+            name = (getattr(episode, 'name', '') or '').upper()
+            if any(alias in name for alias in target_aliases):
+                filtered.append(episode)
+                continue
+
+        # If filtering removed ALL results, return original (don't lose everything)
+        if not filtered and results:
+            print(f"WARNING: Conference filter '{conference_type}' removed all results. Keeping originals.")
+            return results
+
+        return filtered
+
+    def _temporal_rerank(self, results: List[Any], direction: str) -> List[Any]:
+        """Re-rank episode results by year for chronological queries.
+
+        :param results: List of episode results to re-rank
+        :param direction: 'earliest' to sort ascending, 'latest' to sort descending
+        :return: Re-ranked list of results
+        """
+        import re as re_mod
+
+        def get_year(episode) -> int:
+            metadata = getattr(episode, 'metadata', None) or {}
+            year_str = metadata.get('year', '')
+            if year_str:
+                try:
+                    return int(year_str)
+                except (ValueError, TypeError):
+                    pass
+            name = getattr(episode, 'name', '') or ''
+            year_match = re_mod.search(r'(\d{4})', name)
+            if year_match:
+                y = int(year_match.group(1))
+                if 2000 <= y <= 2030:
+                    return y
+            return 9999 if direction == "earliest" else 0
+
+        reverse = direction != "earliest"
+        return sorted(results, key=get_year, reverse=reverse)
+
+    def _classify_episodes_founding(self, episode_results: List[Any]) -> Dict[str, Any]:
+        """Classify episodes as founding or follow-up based on creation vs operational language.
+
+        Scans episode content for creation verbs (establishes, creates, sets up) and
+        follow-up verbs (further develops, also recalling, reaffirms) to separate
+        founding decisions from follow-up decisions.
+
+        :param episode_results: List of episode results to classify
+        :return: Dict with 'founding_episodes', 'followup_episodes', and 'summary'
+        """
+        import re as re_mod
+
+        creation_re = re_mod.compile(
+            r'(?i)\b(establishes?\b|creates?\b|decides\s+to\s+establish\b|'
+            r'launches?\b|sets?\s+up\b|inaugurates?\b)'
+        )
+        followup_re = re_mod.compile(
+            r'(?i)\b(further\s+develops?\b|also\s+recalling\b|'
+            r'builds?\s+on\b|welcomes?\s+the\s+continued\b|reaffirms?\b|'
+            r'operationaliz\w+\b|decides\s+that\s+.{5,40}shall\s+have\b)'
         )
 
-        return results.edges if results and results.edges else []
+        founding = []
+        followup = []
+
+        for episode in episode_results:
+            content = getattr(episode, 'content', '') or ''
+            check_text = content[:3000]
+
+            creation_count = len(creation_re.findall(check_text))
+            followup_count = len(followup_re.findall(check_text))
+
+            metadata = getattr(episode, 'metadata', None) or {}
+            decision_id = metadata.get('decision_id', '')
+            year = metadata.get('year', '?')
+            name = getattr(episode, 'name', '') or ''
+
+            if creation_count > 0 and creation_count >= followup_count:
+                founding.append(episode)
+                print(f"  FOUNDING: Decision {decision_id} ({year}) - {name[:60]} [creation={creation_count}, followup={followup_count}]")
+            else:
+                followup.append(episode)
+                print(f"  FOLLOW-UP: Decision {decision_id} ({year}) - {name[:60]} [creation={creation_count}, followup={followup_count}]")
+
+        # Sort founding by year ascending (earliest first)
+        founding = self._temporal_rerank(founding, "earliest") if founding else []
+        followup = self._temporal_rerank(followup, "earliest") if followup else []
+
+        founding_ids = [getattr(e, 'metadata', {}).get('decision_id', '?') for e in founding if hasattr(e, 'metadata')]
+        followup_ids = [getattr(e, 'metadata', {}).get('decision_id', '?') for e in followup if hasattr(e, 'metadata')]
+
+        summary = f"Found {len(founding)} founding decision(s): {founding_ids} and {len(followup)} follow-up decision(s): {followup_ids}"
+
+        return {
+            "founding_episodes": founding,
+            "followup_episodes": followup,
+            "summary": summary,
+        }
+
+    async def _follow_backward_references(self, episode_results: List[Any]) -> List[str]:
+        """Follow 'recalling' references in episode content to find earlier founding decisions.
+
+        Parses episode content for backward references like "recalling decision X/Y.Z"
+        and fetches those earlier decisions to help identify founding decisions.
+
+        :param episode_results: List of episode results to scan for backward references
+        :return: List of formatted decision result strings
+        """
+        import re as re_mod
+
+        referenced_decision_ids = set()
+        for episode in episode_results:
+            content = getattr(episode, 'content', '') or ''
+            recall_patterns = [
+                r'(?:recalling|recalls|also recalling|further recalling)\s+'
+                r'(?:decision|resolution)\s+(\d+/[A-Z]+\.\d+)',
+                r'(?:pursuant to|in accordance with)\s+'
+                r'(?:decision|resolution)\s+(\d+/[A-Z]+\.\d+)',
+            ]
+            for pattern in recall_patterns:
+                for match in re_mod.finditer(pattern, content, re_mod.IGNORECASE):
+                    ref_id = match.group(1).upper()
+                    referenced_decision_ids.add(ref_id)
+
+        results = []
+        for decision_id in list(referenced_decision_ids)[:5]:
+            print(f"  Following backward reference to Decision {decision_id}...")
+            result = await self._search_by_decision(decision_id, f"decision {decision_id}")
+            if result:
+                results.append(result)
+
+        return results
+
+    async def _search_topic_timeline(
+        self, query: str, query_analysis: Dict[str, Any], limit: int = 20
+    ) -> List[str]:
+        """Search for ALL decisions on a topic and present them chronologically.
+
+        Performs a broad episode search, classifies each decision as founding or
+        follow-up based on creation vs operational language, and returns a sorted
+        timeline of all decisions found.
+
+        :param query: Original search query
+        :param query_analysis: Analysis results from _analyze_query
+        :param limit: Maximum number of episodes to search
+        :return: List of formatted timeline entry strings, sorted chronologically
+        """
+        import re as re_mod
+
+        # Search broadly for episodes on this topic
+        episode_results = await self._search_episodes(query, limit)
+        if not episode_results:
+            return []
+
+        # Apply conference filter if specified
+        conf_filter = query_analysis.get("conference_filter")
+        if conf_filter:
+            episode_results = self._filter_by_conference(episode_results, conf_filter)
+
+        # Collect decision info with year for sorting
+        decisions = []
+        seen_ids = set()
+        for episode in episode_results:
+            metadata = getattr(episode, 'metadata', None) or {}
+            decision_id = metadata.get('decision_id', '')
+            if not decision_id or decision_id in seen_ids:
+                # Fall back to extracting from episode name
+                name = getattr(episode, 'name', '') or ''
+                name_match = re_mod.search(
+                    r'(?:Decision|Resolution)\s+(?:No\.?\s*)?([\dIVXLC]+(?:\s*/\s*[A-Za-z]+\.\d+))',
+                    name, re_mod.IGNORECASE
+                )
+                if name_match:
+                    decision_id = name_match.group(1).strip()
+                else:
+                    continue
+            if decision_id in seen_ids:
+                continue
+            seen_ids.add(decision_id)
+
+            year_str = metadata.get('year', '')
+            year = int(year_str) if year_str else 9999
+            content = getattr(episode, 'content', '') or ''
+
+            # Classify as founding or follow-up
+            creation_re = re_mod.compile(
+                r'(?i)\b(establishes?|creates?|decides\s+to\s+establish|'
+                r'launches?|sets?\s+up)\b'
+            )
+            followup_re = re_mod.compile(
+                r'(?i)\b(further\s+develops?|also\s+recalling|'
+                r'welcomes?\s+the\s+continued|reaffirms?)\b'
+            )
+            creation_count = len(creation_re.findall(content[:2000]))
+            followup_count = len(followup_re.findall(content[:2000]))
+            if creation_count > 0 and creation_count >= followup_count:
+                action_type = "FOUNDING"
+            elif followup_count > creation_count:
+                action_type = "FOLLOW-UP"
+            else:
+                action_type = "RELATED"
+
+            # Extract first substantive sentence as summary
+            first_para = content[:500].split('\n')
+            summary_line = ""
+            for line in first_para:
+                line = line.strip()
+                if len(line) > 30 and not line.startswith("Conference"):
+                    summary_line = line[:200]
+                    break
+
+            conference = metadata.get('conference_type', '')
+            session = metadata.get('session_number', '')
+            location = metadata.get('location', '')
+            formatted = (
+                f"[{year}] Decision {decision_id} ({conference} Session {session}"
+                f"{', ' + location if location else ''}) "
+                f"— {action_type}: {summary_line}"
+            )
+            decisions.append((year, formatted))
+
+        # Sort by year ascending
+        decisions.sort(key=lambda x: x[0])
+
+        # Also follow backward references to find any missing earlier decisions
+        backward_ids = set()
+        for episode in episode_results:
+            content = getattr(episode, 'content', '') or ''
+            for match in re_mod.finditer(
+                r'(?:recalling|also recalling)\s+(?:decision|resolution)\s+(\d+/[A-Z]+\.\d+)',
+                content, re_mod.IGNORECASE
+            ):
+                ref_id = match.group(1).upper()
+                if ref_id not in seen_ids:
+                    backward_ids.add(ref_id)
+
+        # Fetch missing backward-referenced decisions
+        for ref_id in list(backward_ids)[:5]:
+            result = await self._search_by_decision(ref_id, f"decision {ref_id}")
+            if result:
+                decisions.insert(0, (0, f"[EARLIER] Decision {ref_id} — Referenced by later decisions (search for full text)\n{result[:300]}"))
+
+        return [d[1] for d in decisions]
+
+    def _validate_citation(
+        self, claim: str, source_text: str, metadata: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Validate that a claim can be supported by the source text.
+
+        Checks if key terms from the claim appear in the source text and
+        returns confidence score and matching excerpts.
+
+        :param claim: The statement/claim to validate
+        :param source_text: The source document text
+        :param metadata: Document metadata (decision_id, annex, etc.)
+        :return: Validation result with confidence score and evidence
+        """
+        claim_lower = claim.lower()
+        source_lower = source_text.lower()
+
+        # Extract key terms from claim (nouns, verbs, adjectives)
+        import re
+        # Remove common words
+        common_words = {
+            "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for",
+            "of", "with", "by", "from", "is", "are", "was", "were", "be", "been",
+            "has", "have", "had", "do", "does", "did", "will", "would", "should",
+            "could", "may", "might", "must", "shall", "can"
+        }
+
+        # Extract words, filter common words and short words
+        claim_words = [
+            word for word in re.findall(r'\b\w+\b', claim_lower)
+            if word not in common_words and len(word) > 3
+        ]
+
+        # Check how many key terms appear in source
+        matches = sum(1 for word in claim_words if word in source_lower)
+        match_ratio = matches / len(claim_words) if claim_words else 0
+
+        # Find excerpts containing key terms
+        excerpts = []
+        for word in claim_words[:5]:  # Check top 5 key terms
+            pattern = re.compile(r'.{0,100}\b' + re.escape(word) + r'\b.{0,100}', re.IGNORECASE | re.DOTALL)
+            found = pattern.search(source_text)
+            if found:
+                excerpt = found.group(0).strip()
+                # Clean up the excerpt
+                excerpt = ' '.join(excerpt.split())  # Normalize whitespace
+                if excerpt not in excerpts:
+                    excerpts.append(excerpt)
+
+        # Calculate confidence score
+        confidence = "high" if match_ratio >= 0.6 else "medium" if match_ratio >= 0.3 else "low"
+
+        validation_result = {
+            "is_supported": match_ratio >= 0.3,
+            "confidence": confidence,
+            "match_ratio": round(match_ratio, 2),
+            "matched_terms": matches,
+            "total_terms": len(claim_words),
+            "excerpts": excerpts[:3],  # Limit to top 3 excerpts
+            "metadata": metadata,
+        }
+
+        return validation_result
+
+    def _extract_claims_from_fact(self, fact: str) -> List[str]:
+        """
+        Extract individual verifiable claims from a compound fact statement.
+
+        Splits facts on conjunctions and punctuation to isolate individual claims.
+
+        :param fact: The fact statement to break down
+        :return: List of individual claims
+        """
+        import re
+        # Split on common conjunctions and semicolons
+        claims = re.split(r'[;]|\band\b|\bor\b|\balso\b|\bfurthermore\b|\badditionally\b', fact, flags=re.IGNORECASE)
+
+        # Clean and filter
+        claims = [claim.strip() for claim in claims if claim.strip() and len(claim.strip()) > 20]
+
+        # If no splits, return original fact
+        if not claims:
+            claims = [fact]
+
+        return claims
 
     async def _format_facts(self, query: str, results: List[Any]) -> str:
         """
-        Format general graph facts with connected node details.
+        Format general graph facts with SOURCE CITATIONS and connected node details.
+
+        **ENHANCED**: Includes episode sources, metadata, and citation guidance.
 
         :param query: Original search query
         :param results: List of graph fact results
@@ -190,7 +1605,13 @@ class GraphSearchTool(CodedTool):
             return f"No graph facts found matching query: {query}"
 
         output_parts: List[str] = [
-            f"Found {len(results)} relevant facts for query: '{query}'\n",
+            f"SEARCH RESULTS FOR: '{query}'",
+            f"Found {len(results)} knowledge graph fact(s)\n",
+            "=" * 80,
+            "",
+            "NOTE: These facts are extracted from UNFCCC documents.",
+            "For exact text and formal citations, search type='episode' is recommended.",
+            "",
             "=" * 80,
             "",
         ]
@@ -200,11 +1621,35 @@ class GraphSearchTool(CodedTool):
             name: str = getattr(result, "name", "")
             source_uuid: Optional[str] = getattr(result, "source_node_uuid", None)
             target_uuid: Optional[str] = getattr(result, "target_node_uuid", None)
+            episode_uuids: List[str] = getattr(result, "episode_uuids", [])
+            created_at = getattr(result, "created_at", None)
+            valid_at = getattr(result, "valid_at", None)
 
-            output_parts.append(f"FACT {i}")
+            output_parts.append(f"[FACT {i}]")
             if name:
                 output_parts.append(f"Relationship Type: {name}")
             output_parts.append(f"Statement: {fact}")
+
+            # **ENHANCED**: Show source document episodes if available
+            if episode_uuids:
+                output_parts.append(f"\nSource Documents: {len(episode_uuids)} episode(s)")
+                # Fetch episode metadata for proper citations
+                for ep_uuid in episode_uuids[:3]:  # Limit to first 3 for brevity
+                    ep_metadata = await self._get_episode_metadata(ep_uuid)
+                    if ep_metadata:
+                        citation = self._build_citation(
+                            ep_metadata.get("name", ""),
+                            ep_metadata.get("metadata", {}),
+                            ep_metadata.get("source_description", "")
+                        )
+                        if citation:
+                            output_parts.append(f"  • {citation}")
+
+            # Temporal context if available
+            if valid_at:
+                output_parts.append(f"Valid as of: {valid_at}")
+            elif created_at:
+                output_parts.append(f"Recorded: {created_at}")
 
             # Get connected node details
             if source_uuid and target_uuid:
@@ -230,7 +1675,55 @@ class GraphSearchTool(CodedTool):
             output_parts.append("-" * 80)
             output_parts.append("")
 
+        # Add usage guidance
+        output_parts.append("")
+        output_parts.append("HOW TO USE THESE RESULTS:")
+        output_parts.append("- These facts summarize relationships extracted from documents")
+        output_parts.append("- For exact wording and formal citations, use search_type='episode'")
+        output_parts.append("- Verify critical claims by checking the source documents listed above")
+        output_parts.append("- Temporal context (dates) indicates when the information was valid")
+
         return "\n".join(output_parts)
+
+    async def _get_episode_metadata(self, episode_uuid: str) -> Dict[str, Any]:
+        """
+        Fetch episode metadata for citation purposes.
+
+        :param episode_uuid: Episode UUID to look up
+        :return: Dictionary with episode metadata or empty dict if not found
+        """
+        if not GraphSearchTool._driver_instance:
+            return {}
+
+        try:
+            query: str = """
+            MATCH (e:Episodic {uuid: $uuid})
+            RETURN e.name as name, e.source_description as source_description,
+                   e.content as content, e.source as source
+            LIMIT 1
+            """
+            records, _, _ = await GraphSearchTool._driver_instance.execute_query(
+                query, uuid=episode_uuid
+            )
+            if records:
+                record_dict = dict(records[0])
+                # Try to extract metadata from source or name
+                metadata = {}
+                source = record_dict.get("source", "")
+                if source:
+                    # Parse source for decision_id, conference info, etc.
+                    # This is a simplified parser - adjust based on actual data format
+                    import re
+                    decision_match = re.search(r'decision[s]?\s*(\d+/[A-Z]+\.\d+)', source, re.IGNORECASE)
+                    if decision_match:
+                        metadata["decision_id"] = decision_match.group(1)
+
+                record_dict["metadata"] = metadata
+                return record_dict
+            return {}
+        except Exception as e:
+            print(f"Warning: Failed to fetch episode {episode_uuid}: {e}")
+            return {}
 
     async def _get_node_by_uuid(self, uuid: str) -> Dict[str, Any]:
         """
@@ -239,7 +1732,7 @@ class GraphSearchTool(CodedTool):
         :param uuid: Node UUID to look up
         :return: Dictionary with node details or empty dict if not found
         """
-        if not self._driver_instance:
+        if not GraphSearchTool._driver_instance:
             return {}
 
         try:
@@ -248,12 +1741,13 @@ class GraphSearchTool(CodedTool):
             RETURN n.name as name, n.summary as summary, n.entity_type as entity_type, labels(n) as labels
             LIMIT 1
             """
-            records, _, _ = await self._driver_instance.execute_query(query, uuid=uuid)
+            records, _, _ = await GraphSearchTool._driver_instance.execute_query(query, uuid=uuid)
             if records:
                 return dict(records[0])
             return {}
         # pylint: disable=broad-exception-caught
-        except Exception:
+        except Exception as e:
+            print(f"Warning: Failed to fetch node {uuid}: {e}")
             return {}
 
     async def _format_entities(self, query: str, results: List[Any]) -> str:
@@ -319,7 +1813,7 @@ class GraphSearchTool(CodedTool):
         :param uuid: Entity UUID to find connections for
         :return: List of connection dictionaries
         """
-        if not self._driver_instance:
+        if not GraphSearchTool._driver_instance:
             return []
 
         try:
@@ -328,10 +1822,11 @@ class GraphSearchTool(CodedTool):
             RETURN r.name as relationship, target.name as target_name, r.fact as fact
             LIMIT 5
             """
-            records, _, _ = await self._driver_instance.execute_query(query, uuid=uuid)
+            records, _, _ = await GraphSearchTool._driver_instance.execute_query(query, uuid=uuid)
             return [dict(record) for record in records]
         # pylint: disable=broad-exception-caught
-        except Exception:
+        except Exception as e:
+            print(f"Warning: Failed to fetch connections for entity {uuid}: {e}")
             return []
 
     async def _format_relationships(self, query: str, results: List[Any]) -> str:
@@ -388,3 +1883,171 @@ class GraphSearchTool(CodedTool):
             output_parts.append("")
 
         return "\n".join(output_parts)
+
+    async def _format_episodes(self, query: str, results: List[Any]) -> str:
+        """
+        Format episode nodes with primary source content and metadata.
+
+        If total content exceeds MAX_OUTPUT_CHARS, each episode's content
+        is truncated to fit within context limits.
+
+        :param query: Original search query
+        :param results: List of episode node results
+        :return: Formatted string representation with STRICT CITATIONS
+        """
+        if not results:
+            return f"No primary source documents found matching query: {query}"
+
+        # Calculate total content size to determine per-episode budget
+        total_content_chars = sum(len(getattr(ep, "content", "") or "") for ep in results)
+        needs_truncation = total_content_chars > self.MAX_OUTPUT_CHARS
+
+        # If truncating, divide budget evenly across episodes
+        if needs_truncation and len(results) > 0:
+            per_episode_limit = self.MAX_OUTPUT_CHARS // len(results)
+            print(f"Total content: {total_content_chars} chars > {self.MAX_OUTPUT_CHARS} limit. Truncating each episode to ~{per_episode_limit} chars.")
+        else:
+            per_episode_limit = 0  # No limit
+
+        output_parts: List[str] = [
+            f"SEARCH RESULTS FOR: '{query}'",
+            f"Found {len(results)} source document(s)\n",
+            "=" * 80,
+            "",
+        ]
+
+        for i, episode in enumerate(results, 1):
+            name = getattr(episode, "name", "Unnamed Episode")
+            content = getattr(episode, "content", "") or ""
+            source_description = getattr(episode, "source_description", "")
+
+            # Get metadata from episode object first (most reliable), then fall back to DB query
+            ep_metadata = getattr(episode, 'metadata', None) or {}
+            db_metadata: Dict[str, Any] = await self._get_episode_metadata(
+                getattr(episode, "uuid", "")
+            )
+            # Merge: episode object metadata takes priority
+            metadata = {**db_metadata, **{k: v for k, v in ep_metadata.items() if v}}
+
+            # Build formal citation
+            citation = self._build_citation(name, metadata, source_description)
+
+            # Extract key identifiers for prominent header
+            decision_id = metadata.get("decision_id", "")
+            annex_id = metadata.get("annex_id", "")
+            year = metadata.get("year", "")
+            conf_type = metadata.get("conference_type", "")
+            action_type = metadata.get("decision_action_type", "")
+
+            # Prominent header so agent can't miss decision IDs
+            output_parts.append(f"[RESULT {i}]")
+            if decision_id:
+                header = f">>> DECISION {decision_id}"
+                if year:
+                    header += f" ({year})"
+                if action_type:
+                    header += f" [{action_type.upper()}]"
+                header += " <<<"
+                output_parts.append(header)
+            if annex_id:
+                output_parts.append(f">>> ANNEX {annex_id} to Decision {decision_id} <<<")
+            output_parts.append(f"CITATION: {citation}")
+            if conf_type:
+                output_parts.append(f"Conference: {conf_type} {year}")
+            output_parts.append("")
+            output_parts.append("EXACT TEXT FROM SOURCE:")
+            output_parts.append("-" * 80)
+
+            if content:
+                if needs_truncation:
+                    output_parts.append(self._truncate_content(content.strip(), per_episode_limit))
+                else:
+                    output_parts.append(content.strip())
+            else:
+                output_parts.append("[No content available in database]")
+
+            output_parts.append("")
+            output_parts.append("=" * 80)
+            output_parts.append("")
+
+        return "\n".join(output_parts)
+
+    def _build_citation(self, episode_name: str, metadata: Dict[str, Any],
+                       source_description: str) -> str:
+        """
+        Build a formal citation string for an episode.
+
+        :param episode_name: The episode name from the database
+        :param metadata: Episode metadata dictionary
+        :param source_description: Human-readable source description
+        :return: Formatted citation string
+        """
+        citation_parts = []
+
+        # Extract decision/resolution from name if not in metadata
+        decision_id = metadata.get("decision_id")
+        if not decision_id and "::" in episode_name:
+            # Try to extract from episode name
+            title_part = episode_name.split("::", 1)[1] if "::" in episode_name else ""
+            if "Decision" in title_part or "Resolution" in title_part:
+                # Extract decision number from title
+                import re
+                match = re.search(
+                    r"(?:Decision|Resolution)\s+(?:No\.?\s*)?([\dIVXLC]+(?:/[A-Za-z]+\.\d+)?)",
+                    title_part
+                )
+                if match:
+                    decision_id = match.group(1)
+
+        if decision_id:
+            citation_parts.append(f"Decision {decision_id}")
+
+        # Add annex if present
+        annex_id = metadata.get("annex_id")
+        if annex_id:
+            citation_parts.append(f"Annex {annex_id}")
+
+        # Add conference info
+        conf_type = metadata.get("conference_type")
+        session = metadata.get("session_number")
+        year = metadata.get("year")
+
+        if conf_type and session and year:
+            citation_parts.append(f"{conf_type} Session {session} ({year})")
+        elif source_description:
+            citation_parts.append(source_description)
+
+        if citation_parts:
+            return ", ".join(citation_parts)
+        else:
+            # Fallback to episode name
+            return f"Source: {episode_name}"
+
+    async def _get_episode_metadata(self, uuid: str) -> Dict[str, Any]:
+        """
+        Fetch episode metadata by UUID.
+
+        :param uuid: Episode UUID to look up
+        :return: Dictionary with episode metadata or empty dict if not found
+        """
+        if not GraphSearchTool._driver_instance or not uuid:
+            return {}
+
+        try:
+            query: str = """
+            MATCH (e:Episode {uuid: $uuid})
+            RETURN e.decision_id as decision_id,
+                   e.conference_type as conference_type,
+                   e.year as year,
+                   e.session_number as session_number,
+                   e.annex_id as annex_id
+            LIMIT 1
+            """
+            records, _, _ = await GraphSearchTool._driver_instance.execute_query(query, uuid=uuid)
+            if records:
+                return dict(records[0])
+            return {}
+        # pylint: disable=broad-exception-caught
+        except Exception as e:
+            print(f"Warning: Failed to fetch episode metadata {uuid}: {e}")
+            return {}

--- a/coded_tools/graph_rag/graph_search_tool.py
+++ b/coded_tools/graph_rag/graph_search_tool.py
@@ -44,7 +44,20 @@ Search Types:
        Returns original document text with metadata (conference, year, decision IDs).
        Best for getting exact wording from source documents.
 """
+
+# pylint: disable=too-many-lines
+# pylint: disable=wrong-import-position
+# pylint: disable=line-too-long
+# pylint: disable=too-many-locals
+# pylint: disable=too-many-return-statements
+# pylint: disable=too-many-branches
+# pylint: disable=too-many-statements
+# pylint: disable=too-many-boolean-expressions
+# pylint: disable=protected-access
+# pylint: disable=broad-exception-caught
+
 import os
+import re
 import traceback
 from pathlib import Path
 from typing import Any
@@ -62,6 +75,9 @@ load_dotenv(dotenv_path=_current_dir / ".env")
 from graphiti_core import Graphiti
 from graphiti_core.driver.falkordb_driver import FalkorDriver
 from graphiti_core.driver.neo4j_driver import Neo4jDriver
+from graphiti_core.search.search_config_recipes import COMBINED_HYBRID_SEARCH_RRF
+from graphiti_core.search.search_config_recipes import EDGE_HYBRID_SEARCH_RRF
+from graphiti_core.search.search_config_recipes import NODE_HYBRID_SEARCH_RRF
 
 
 class GraphSearchTool(CodedTool):
@@ -197,7 +213,7 @@ class GraphSearchTool(CodedTool):
         # pylint: disable=broad-exception-caught
         except Exception as exception:
             error_msg: str = (
-                f"Unexpected error during graph search:\n"
+                "Unexpected error during graph search:\n"
                 f"  Error type: {type(exception).__name__}\n"
                 f"  Error message: {str(exception)}\n"
                 f"  Query: {args.get('query', 'N/A')}\n"
@@ -257,7 +273,6 @@ class GraphSearchTool(CodedTool):
                 analysis["key_concepts"].append(concept)
 
         # Extract temporal markers
-        import re
         years = re.findall(r'\b(19\d{2}|20\d{2})\b', query)
         analysis["temporal_markers"].extend(years)
 
@@ -594,7 +609,7 @@ class GraphSearchTool(CodedTool):
         if decision_results:
             output_parts.append("=" * 80)
             output_parts.append("SPECIFIC DECISION (EXACT MATCH)")
-            output_parts.append(f"Direct result for the decision referenced in your query")
+            output_parts.append("Direct result for the decision referenced in your query")
             output_parts.append("=" * 80)
             output_parts.append("")
             output_parts.append(decision_results)
@@ -742,7 +757,7 @@ class GraphSearchTool(CodedTool):
             if neo4j_uri and neo4j_user and neo4j_password:
                 # Use Neo4j
                 GraphSearchTool._db_type = "neo4j"
-                print(f"Detected Neo4j configuration")
+                print("Detected Neo4j configuration")
                 print(f"Initializing Neo4j connection to {neo4j_uri}")
 
                 GraphSearchTool._driver_instance = Neo4jDriver(
@@ -766,14 +781,16 @@ class GraphSearchTool(CodedTool):
                 # Validate port is a valid integer
                 try:
                     port = int(port_str)
-                except (ValueError, TypeError):
-                    raise ValueError(f"FALKORDB_PORT must be a valid integer, got: {port_str}")
+                except (ValueError, TypeError) as exc:
+                    raise ValueError(
+                        f"FALKORDB_PORT must be a valid integer, got: {port_str}"
+                    ) from exc
 
                 username = os.getenv("FALKORDB_USERNAME")
                 password = os.getenv("FALKORDB_PASSWORD")
                 database = os.getenv("GRAPH_NAME", "unfccc_knowledge_graph")
 
-                print(f"Detected FalkorDB configuration (or using defaults)")
+                print("Detected FalkorDB configuration (or using defaults)")
                 print(f"Initializing FalkorDB connection to {host}:{port}, database: {database}")
 
                 GraphSearchTool._driver_instance = FalkorDriver(
@@ -795,7 +812,7 @@ class GraphSearchTool(CodedTool):
             if GraphSearchTool._db_type == "neo4j":
                 error_msg = (
                     f"Failed to initialize Neo4j connection: {str(e)}\n"
-                    f"Connection details:\n"
+                    "Connection details:\n"
                     f"  URI: {os.getenv('NEO4J_URI', 'NOT SET')}\n"
                     f"  User: {os.getenv('NEO4J_USER', 'NOT SET')}\n"
                     "Please verify:\n"
@@ -806,7 +823,7 @@ class GraphSearchTool(CodedTool):
             else:
                 error_msg = (
                     f"Failed to initialize FalkorDB connection: {str(e)}\n"
-                    f"Connection details:\n"
+                    "Connection details:\n"
                     f"  Host: {os.getenv('FALKORDB_HOST', 'localhost')}\n"
                     f"  Port: {os.getenv('FALKORDB_PORT', '6379')}\n"
                     f"  Database: {os.getenv('GRAPH_NAME', 'unfccc_knowledge_graph')}\n"
@@ -850,9 +867,6 @@ class GraphSearchTool(CodedTool):
         :raises: Exception if search fails
         """
         try:
-            from graphiti_core.search.search_config_recipes import \
-                NODE_HYBRID_SEARCH_RRF
-
             print(f"Searching entities: query='{query[:50]}...', limit={limit}")
             config = NODE_HYBRID_SEARCH_RRF.model_copy(deep=True)
             config.limit = limit
@@ -878,9 +892,6 @@ class GraphSearchTool(CodedTool):
         :raises: Exception if search fails
         """
         try:
-            from graphiti_core.search.search_config_recipes import \
-                EDGE_HYBRID_SEARCH_RRF
-
             print(f"Searching relationships: query='{query[:50]}...', limit={limit}")
             config = EDGE_HYBRID_SEARCH_RRF.model_copy(deep=True)
             config.limit = limit
@@ -911,10 +922,6 @@ class GraphSearchTool(CodedTool):
         :raises: Exception if search fails
         """
         try:
-            from graphiti_core.search.search_config_recipes import (
-                COMBINED_HYBRID_SEARCH_RRF
-            )
-
             # **ENHANCED SEARCH QUALITY**: Expand query with UNFCCC-specific terminology
             expanded_query = self._expand_query_terms(query)
             print(f"Searching episodes: original='{query[:50]}...', expanded='{expanded_query[:70]}...'")
@@ -946,11 +953,9 @@ class GraphSearchTool(CodedTool):
         :param query: Original query for context
         :return: Formatted decision text or empty string if not found
         """
-        try:
-            from graphiti_core.search.search_config_recipes import (
-                COMBINED_HYBRID_SEARCH_RRF
-            )
+        _ = query
 
+        try:
             # Strategy 1: Semantic search + metadata matching
             search_query = f"decision {decision_id}"
             print(f"Searching for decision: {decision_id}")
@@ -986,7 +991,6 @@ class GraphSearchTool(CodedTool):
 
         except Exception as e:
             print(f"Error during decision search: {e}")
-            import traceback
             traceback.print_exc()
             return ""
 
@@ -1005,7 +1009,7 @@ class GraphSearchTool(CodedTool):
         formatted_result = f">>> DECISION {decision_id} ({year}){action_label} <<<\n"
         formatted_result += f"Conference: {conference}\n"
         formatted_result += f"Year: {year}, Location: {location}\n"
-        formatted_result += f"\nEXACT TEXT FROM SOURCE:\n"
+        formatted_result += "\nEXACT TEXT FROM SOURCE:\n"
         formatted_result += "-" * 80 + "\n"
         formatted_result += f"{episode_content}\n"
 
@@ -1054,7 +1058,7 @@ class GraphSearchTool(CodedTool):
 
                 formatted_result = f">>> DECISION {decision_id} <<<\n"
                 formatted_result += f"Source: {source_desc or name}\n"
-                formatted_result += f"\nEXACT TEXT FROM SOURCE:\n"
+                formatted_result += "\nEXACT TEXT FROM SOURCE:\n"
                 formatted_result += "-" * 80 + "\n"
                 formatted_result += f"{content}\n"
 
@@ -1065,7 +1069,6 @@ class GraphSearchTool(CodedTool):
 
         except Exception as e:
             print(f"Error during direct Cypher search: {e}")
-            import traceback
             traceback.print_exc()
             return ""
 
@@ -1083,8 +1086,6 @@ class GraphSearchTool(CodedTool):
         :param query_analysis: Analysis results containing paragraph_refs
         :return: List of formatted paragraph results
         """
-        import re
-
         paragraph_refs = query_analysis.get("paragraph_refs", [])
         if not paragraph_refs:
             return []
@@ -1107,10 +1108,6 @@ class GraphSearchTool(CodedTool):
         print(f"Searching for episodes containing decision: {decision_id or 'unknown (using query)'}")
 
         try:
-            from graphiti_core.search.search_config_recipes import (
-                COMBINED_HYBRID_SEARCH_RRF
-            )
-
             # Use combined search to find episodes
             config = COMBINED_HYBRID_SEARCH_RRF.model_copy(deep=True)
             config.limit = 10  # Get more candidates to find the right decision
@@ -1171,7 +1168,6 @@ class GraphSearchTool(CodedTool):
 
         except Exception as e:
             print(f"Error during paragraph metadata search: {e}")
-            import traceback
             traceback.print_exc()
 
         return results
@@ -1232,8 +1228,6 @@ class GraphSearchTool(CodedTool):
         :param conference_type: Conference type to filter by (e.g., "CMA", "COP", "CMP")
         :return: Filtered list of results matching the conference type
         """
-        import re as re_mod
-
         # Normalize conference type aliases
         conf_aliases = {
             "COP": ["COP", "CP"],
@@ -1280,8 +1274,6 @@ class GraphSearchTool(CodedTool):
         :param direction: 'earliest' to sort ascending, 'latest' to sort descending
         :return: Re-ranked list of results
         """
-        import re as re_mod
-
         def get_year(episode) -> int:
             metadata = getattr(episode, 'metadata', None) or {}
             year_str = metadata.get('year', '')
@@ -1291,7 +1283,7 @@ class GraphSearchTool(CodedTool):
                 except (ValueError, TypeError):
                     pass
             name = getattr(episode, 'name', '') or ''
-            year_match = re_mod.search(r'(\d{4})', name)
+            year_match = re.search(r'(\d{4})', name)
             if year_match:
                 y = int(year_match.group(1))
                 if 2000 <= y <= 2030:
@@ -1311,13 +1303,11 @@ class GraphSearchTool(CodedTool):
         :param episode_results: List of episode results to classify
         :return: Dict with 'founding_episodes', 'followup_episodes', and 'summary'
         """
-        import re as re_mod
-
-        creation_re = re_mod.compile(
+        creation_re = re.compile(
             r'(?i)\b(establishes?\b|creates?\b|decides\s+to\s+establish\b|'
             r'launches?\b|sets?\s+up\b|inaugurates?\b)'
         )
-        followup_re = re_mod.compile(
+        followup_re = re.compile(
             r'(?i)\b(further\s+develops?\b|also\s+recalling\b|'
             r'builds?\s+on\b|welcomes?\s+the\s+continued\b|reaffirms?\b|'
             r'operationaliz\w+\b|decides\s+that\s+.{5,40}shall\s+have\b)'
@@ -1369,8 +1359,6 @@ class GraphSearchTool(CodedTool):
         :param episode_results: List of episode results to scan for backward references
         :return: List of formatted decision result strings
         """
-        import re as re_mod
-
         referenced_decision_ids = set()
         for episode in episode_results:
             content = getattr(episode, 'content', '') or ''
@@ -1381,7 +1369,7 @@ class GraphSearchTool(CodedTool):
                 r'(?:decision|resolution)\s+(\d+/[A-Z]+\.\d+)',
             ]
             for pattern in recall_patterns:
-                for match in re_mod.finditer(pattern, content, re_mod.IGNORECASE):
+                for match in re.finditer(pattern, content, re.IGNORECASE):
                     ref_id = match.group(1).upper()
                     referenced_decision_ids.add(ref_id)
 
@@ -1408,8 +1396,6 @@ class GraphSearchTool(CodedTool):
         :param limit: Maximum number of episodes to search
         :return: List of formatted timeline entry strings, sorted chronologically
         """
-        import re as re_mod
-
         # Search broadly for episodes on this topic
         episode_results = await self._search_episodes(query, limit)
         if not episode_results:
@@ -1429,9 +1415,9 @@ class GraphSearchTool(CodedTool):
             if not decision_id or decision_id in seen_ids:
                 # Fall back to extracting from episode name
                 name = getattr(episode, 'name', '') or ''
-                name_match = re_mod.search(
+                name_match = re.search(
                     r'(?:Decision|Resolution)\s+(?:No\.?\s*)?([\dIVXLC]+(?:\s*/\s*[A-Za-z]+\.\d+))',
-                    name, re_mod.IGNORECASE
+                    name, re.IGNORECASE
                 )
                 if name_match:
                     decision_id = name_match.group(1).strip()
@@ -1446,11 +1432,11 @@ class GraphSearchTool(CodedTool):
             content = getattr(episode, 'content', '') or ''
 
             # Classify as founding or follow-up
-            creation_re = re_mod.compile(
+            creation_re = re.compile(
                 r'(?i)\b(establishes?|creates?|decides\s+to\s+establish|'
                 r'launches?|sets?\s+up)\b'
             )
-            followup_re = re_mod.compile(
+            followup_re = re.compile(
                 r'(?i)\b(further\s+develops?|also\s+recalling|'
                 r'welcomes?\s+the\s+continued|reaffirms?)\b'
             )
@@ -1489,9 +1475,9 @@ class GraphSearchTool(CodedTool):
         backward_ids = set()
         for episode in episode_results:
             content = getattr(episode, 'content', '') or ''
-            for match in re_mod.finditer(
+            for match in re.finditer(
                 r'(?:recalling|also recalling)\s+(?:decision|resolution)\s+(\d+/[A-Z]+\.\d+)',
-                content, re_mod.IGNORECASE
+                content, re.IGNORECASE
             ):
                 ref_id = match.group(1).upper()
                 if ref_id not in seen_ids:
@@ -1523,7 +1509,6 @@ class GraphSearchTool(CodedTool):
         source_lower = source_text.lower()
 
         # Extract key terms from claim (nouns, verbs, adjectives)
-        import re
         # Remove common words
         common_words = {
             "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for",
@@ -1578,7 +1563,6 @@ class GraphSearchTool(CodedTool):
         :param fact: The fact statement to break down
         :return: List of individual claims
         """
-        import re
         # Split on common conjunctions and semicolons
         claims = re.split(r'[;]|\band\b|\bor\b|\balso\b|\bfurthermore\b|\badditionally\b', fact, flags=re.IGNORECASE)
 
@@ -1684,46 +1668,6 @@ class GraphSearchTool(CodedTool):
         output_parts.append("- Temporal context (dates) indicates when the information was valid")
 
         return "\n".join(output_parts)
-
-    async def _get_episode_metadata(self, episode_uuid: str) -> Dict[str, Any]:
-        """
-        Fetch episode metadata for citation purposes.
-
-        :param episode_uuid: Episode UUID to look up
-        :return: Dictionary with episode metadata or empty dict if not found
-        """
-        if not GraphSearchTool._driver_instance:
-            return {}
-
-        try:
-            query: str = """
-            MATCH (e:Episodic {uuid: $uuid})
-            RETURN e.name as name, e.source_description as source_description,
-                   e.content as content, e.source as source
-            LIMIT 1
-            """
-            records, _, _ = await GraphSearchTool._driver_instance.execute_query(
-                query, uuid=episode_uuid
-            )
-            if records:
-                record_dict = dict(records[0])
-                # Try to extract metadata from source or name
-                metadata = {}
-                source = record_dict.get("source", "")
-                if source:
-                    # Parse source for decision_id, conference info, etc.
-                    # This is a simplified parser - adjust based on actual data format
-                    import re
-                    decision_match = re.search(r'decision[s]?\s*(\d+/[A-Z]+\.\d+)', source, re.IGNORECASE)
-                    if decision_match:
-                        metadata["decision_id"] = decision_match.group(1)
-
-                record_dict["metadata"] = metadata
-                return record_dict
-            return {}
-        except Exception as e:
-            print(f"Warning: Failed to fetch episode {episode_uuid}: {e}")
-            return {}
 
     async def _get_node_by_uuid(self, uuid: str) -> Dict[str, Any]:
         """
@@ -1991,7 +1935,6 @@ class GraphSearchTool(CodedTool):
             title_part = episode_name.split("::", 1)[1] if "::" in episode_name else ""
             if "Decision" in title_part or "Resolution" in title_part:
                 # Extract decision number from title
-                import re
                 match = re.search(
                     r"(?:Decision|Resolution)\s+(?:No\.?\s*)?([\dIVXLC]+(?:/[A-Za-z]+\.\d+)?)",
                     title_part
@@ -2019,9 +1962,8 @@ class GraphSearchTool(CodedTool):
 
         if citation_parts:
             return ", ".join(citation_parts)
-        else:
-            # Fallback to episode name
-            return f"Source: {episode_name}"
+        # Fallback to episode name
+        return f"Source: {episode_name}"
 
     async def _get_episode_metadata(self, uuid: str) -> Dict[str, Any]:
         """

--- a/coded_tools/graph_rag/graph_search_tool.py
+++ b/coded_tools/graph_rag/graph_search_tool.py
@@ -43,18 +43,7 @@ Search Types:
     4. "episode": Searches for primary source document content (episodes).
        Returns original document text with metadata (conference, year, decision IDs).
        Best for getting exact wording from source documents.
-"""
-
-# pylint: disable=too-many-lines
-# pylint: disable=wrong-import-position
-# pylint: disable=line-too-long
-# pylint: disable=too-many-locals
-# pylint: disable=too-many-return-statements
-# pylint: disable=too-many-branches
-# pylint: disable=too-many-statements
-# pylint: disable=too-many-boolean-expressions
-# pylint: disable=protected-access
-# pylint: disable=broad-exception-caught
+"""  # pylint: disable=too-many-lines
 
 import os
 import re
@@ -72,12 +61,14 @@ from neuro_san.interfaces.coded_tool import CodedTool
 _current_dir = Path(__file__).parent
 load_dotenv(dotenv_path=_current_dir / ".env")
 
+# pylint: disable=wrong-import-position
 from graphiti_core import Graphiti
 from graphiti_core.driver.falkordb_driver import FalkorDriver
 from graphiti_core.driver.neo4j_driver import Neo4jDriver
 from graphiti_core.search.search_config_recipes import COMBINED_HYBRID_SEARCH_RRF
 from graphiti_core.search.search_config_recipes import EDGE_HYBRID_SEARCH_RRF
 from graphiti_core.search.search_config_recipes import NODE_HYBRID_SEARCH_RRF
+# pylint: enable=wrong-import-position
 
 
 class GraphSearchTool(CodedTool):
@@ -96,7 +87,9 @@ class GraphSearchTool(CodedTool):
     # Max output size in characters (~10K tokens) to stay within GPT-4o context
     MAX_OUTPUT_CHARS = 40000
 
-    async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> str:
+    async def async_invoke(  # pylint: disable=too-many-locals,too-many-return-statements,too-many-branches,too-many-statements
+        self, args: Dict[str, Any], sly_data: Dict[str, Any],
+    ) -> str:
         """
         Execute graph relationship search and return relevant facts.
 
@@ -166,7 +159,16 @@ class GraphSearchTool(CodedTool):
 
             # **ENHANCED SEARCH QUALITY**: Analyze query and determine optimal search strategy
             query_analysis = self._analyze_query(query)
-            print(f"Query analysis: intent={query_analysis['intent']}, key_concepts={query_analysis['key_concepts']}, decision_id={query_analysis.get('decision_id')}, paragraph_refs={query_analysis.get('paragraph_refs', [])}, temporal_direction={query_analysis.get('temporal_direction')}, is_timeline={query_analysis.get('is_timeline_query')}, is_identification={query_analysis.get('is_identification_query')}, conference_filter={query_analysis.get('conference_filter')}")
+            print(
+                f"Query analysis: intent={query_analysis['intent']}, "
+                f"key_concepts={query_analysis['key_concepts']}, "
+                f"decision_id={query_analysis.get('decision_id')}, "
+                f"paragraph_refs={query_analysis.get('paragraph_refs', [])}, "
+                f"temporal_direction={query_analysis.get('temporal_direction')}, "
+                f"is_timeline={query_analysis.get('is_timeline_query')}, "
+                f"is_identification={query_analysis.get('is_identification_query')}, "
+                f"conference_filter={query_analysis.get('conference_filter')}"
+            )
 
             # If user didn't specify search_type, auto-select based on query intent
             if args.get("search_type") is None:
@@ -223,7 +225,9 @@ class GraphSearchTool(CodedTool):
             traceback.print_exc()
             return error_msg
 
-    def _analyze_query(self, query: str) -> Dict[str, Any]:
+    def _analyze_query(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+        self, query: str,
+    ) -> Dict[str, Any]:
         """
         Analyze the query to extract key information and determine optimal search strategy.
 
@@ -449,7 +453,9 @@ class GraphSearchTool(CodedTool):
             analysis["complexity"] = "low"
 
         # Force high complexity for temporal/timeline/identification queries
-        if analysis.get("temporal_direction") or analysis.get("is_timeline_query") or analysis.get("is_identification_query"):
+        if (analysis.get("temporal_direction")
+                or analysis.get("is_timeline_query")
+                or analysis.get("is_identification_query")):
             analysis["complexity"] = "high"
 
         # Recommend search type based on analysis
@@ -465,8 +471,8 @@ class GraphSearchTool(CodedTool):
 
         return analysis
 
-    async def _multi_stage_search(
-        self, query: str, query_analysis: Dict[str, Any], limit: int
+    async def _multi_stage_search(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+        self, query: str, query_analysis: Dict[str, Any], limit: int,
     ) -> tuple:
         """
         Perform multi-stage search for complex queries requiring comprehensive answers.
@@ -493,7 +499,10 @@ class GraphSearchTool(CodedTool):
         # PRIORITY 1: If specific paragraphs are referenced, try paragraph-based search
         paragraph_results = []
         if query_analysis.get("paragraph_refs"):
-            print(f"Detected {len(query_analysis['paragraph_refs'])} paragraph reference(s), attempting metadata search...")
+            print(
+                f"Detected {len(query_analysis['paragraph_refs'])} paragraph reference(s), "
+                "attempting metadata search..."
+            )
             paragraph_results = await self._search_by_paragraph(query, query_analysis)
 
             # If we found specific paragraphs, prioritize those and do lighter follow-up searches
@@ -553,7 +562,8 @@ class GraphSearchTool(CodedTool):
         referenced_decisions = []
         should_follow_refs = (
             query_analysis.get("follow_references")
-            or (query_analysis.get("is_identification_query") and query_analysis.get("temporal_direction") == "earliest")
+            or (query_analysis.get("is_identification_query")
+                and query_analysis.get("temporal_direction") == "earliest")
         )
         if should_follow_refs and episode_results:
             print("Stage 2B: Following backward references for chronological/creation query...")
@@ -578,7 +588,10 @@ class GraphSearchTool(CodedTool):
         founding_analysis = None
         is_creation_query = query_analysis.get("temporal_direction") == "earliest" or (
             query_analysis.get("is_identification_query") and any(
-                w in query.lower() for w in ["creates", "created", "establishes", "established", "set up", "sets up", "launches", "launched", "founded"]
+                w in query.lower() for w in [
+                    "creates", "created", "establishes", "established",
+                    "set up", "sets up", "launches", "launched", "founded",
+                ]
             )
         )
         if is_creation_query and episode_results:
@@ -598,7 +611,8 @@ class GraphSearchTool(CodedTool):
             f"MULTI-STAGE SEARCH RESULTS FOR: '{query}'",
             f"Query Complexity: {query_analysis['complexity'].upper()}",
             f"Query Intent: {query_analysis['intent'].upper()}",
-            f"Key Concepts: {', '.join(query_analysis['key_concepts'][:5]) if query_analysis['key_concepts'] else 'None detected'}",
+            f"Key Concepts: "
+            f"{', '.join(query_analysis['key_concepts'][:5]) if query_analysis['key_concepts'] else 'None detected'}",
             f"Conference Filter: {conf_filter if conf_filter else 'None (all conferences)'}",
             "",
             "=" * 80,
@@ -655,7 +669,10 @@ class GraphSearchTool(CodedTool):
             if is_creation_query:
                 output_parts.append(">>> EARLIER REFERENCED DECISIONS (POTENTIAL FOUNDING DECISIONS) <<<")
                 output_parts.append("These were recalled/referenced by later decisions.")
-                output_parts.append("CHECK THESE FIRST — the founding decision is often referenced by later follow-ups.")
+                output_parts.append(
+                    "CHECK THESE FIRST — the founding decision is often "
+                    "referenced by later follow-ups."
+                )
             else:
                 output_parts.append("EARLIER REFERENCED DECISIONS (TRACED VIA BACKWARD REFERENCES)")
                 output_parts.append("These were recalled/referenced by the results above")
@@ -708,7 +725,13 @@ class GraphSearchTool(CodedTool):
             output_parts.append(rel_text)
             output_parts.append("")
 
-        if not decision_results and not paragraph_results and not referenced_decisions and not timeline_results and not episode_results and not entity_results and not relationship_results:
+        no_results = (
+            not decision_results and not paragraph_results
+            and not referenced_decisions and not timeline_results
+            and not episode_results and not entity_results
+            and not relationship_results
+        )
+        if no_results:
             output_parts.append("No results found across all search stages.")
             output_parts.append("")
             output_parts.append("Suggestions:")
@@ -871,11 +894,11 @@ class GraphSearchTool(CodedTool):
             config = NODE_HYBRID_SEARCH_RRF.model_copy(deep=True)
             config.limit = limit
 
-            results = await GraphSearchTool._graphiti_instance._search(
+            results = await GraphSearchTool._graphiti_instance._search(  # pylint: disable=protected-access
                 query=query, config=config
             )
 
-            node_count = len(results.nodes) if results and results.nodes else 0
+            node_count = len(results.nodes)if results and results.nodes else 0
             print(f"Entity search returned {node_count} nodes")
             return results.nodes if results and results.nodes else []
         except Exception as e:
@@ -896,11 +919,11 @@ class GraphSearchTool(CodedTool):
             config = EDGE_HYBRID_SEARCH_RRF.model_copy(deep=True)
             config.limit = limit
 
-            results = await GraphSearchTool._graphiti_instance._search(
+            results = await GraphSearchTool._graphiti_instance._search(  # pylint: disable=protected-access
                 query=query, config=config
             )
 
-            edge_count = len(results.edges) if results and results.edges else 0
+            edge_count = len(results.edges)if results and results.edges else 0
             print(f"Relationship search returned {edge_count} edges")
             return results.edges if results and results.edges else []
         except Exception as e:
@@ -930,7 +953,7 @@ class GraphSearchTool(CodedTool):
             config = COMBINED_HYBRID_SEARCH_RRF.model_copy(deep=True)
             config.limit = limit
 
-            results = await GraphSearchTool._graphiti_instance._search(
+            results = await GraphSearchTool._graphiti_instance._search(  # pylint: disable=protected-access
                 query=expanded_query, config=config
             )
 
@@ -963,7 +986,7 @@ class GraphSearchTool(CodedTool):
             config = COMBINED_HYBRID_SEARCH_RRF.model_copy(deep=True)
             config.limit = 10
 
-            search_results = await GraphSearchTool._graphiti_instance._search(
+            search_results = await GraphSearchTool._graphiti_instance._search(  # pylint: disable=protected-access
                 query=search_query, config=config
             )
 
@@ -977,7 +1000,8 @@ class GraphSearchTool(CodedTool):
 
                 episode_decision_id = episode.metadata.get("decision_id", "")
                 if episode_decision_id and episode_decision_id.strip().upper() == decision_id.strip().upper():
-                    print(f"Found exact match via semantic search: {episode.name if hasattr(episode, 'name') else 'Unknown'}")
+                    ep_name = episode.name if hasattr(episode, 'name') else 'Unknown'
+                    print(f"Found exact match via semantic search: {ep_name}")
                     return self._format_decision_result(decision_id, episode)
 
             # Strategy 2: Direct Cypher query as fallback
@@ -989,7 +1013,7 @@ class GraphSearchTool(CodedTool):
             print(f"WARNING: Decision {decision_id} not found by any method")
             return ""
 
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             print(f"Error during decision search: {e}")
             traceback.print_exc()
             return ""
@@ -1067,13 +1091,13 @@ class GraphSearchTool(CodedTool):
             print(f"Direct Cypher query found no results for Decision {decision_id}")
             return ""
 
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             print(f"Error during direct Cypher search: {e}")
             traceback.print_exc()
             return ""
 
-    async def _search_by_paragraph(
-        self, query: str, query_analysis: Dict[str, Any]
+    async def _search_by_paragraph(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+        self, query: str, query_analysis: Dict[str, Any],
     ) -> List[str]:
         """
         Search for specific paragraphs using metadata paragraph_index.
@@ -1112,7 +1136,7 @@ class GraphSearchTool(CodedTool):
             config = COMBINED_HYBRID_SEARCH_RRF.model_copy(deep=True)
             config.limit = 10  # Get more candidates to find the right decision
 
-            search_results = await GraphSearchTool._graphiti_instance._search(
+            search_results = await GraphSearchTool._graphiti_instance._search(  # pylint: disable=protected-access
                 query=search_query, config=config
             )
 
@@ -1166,7 +1190,7 @@ class GraphSearchTool(CodedTool):
                 if not found:
                     print(f"WARNING: Could not find paragraph {para_id} in any episode metadata")
 
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             print(f"Error during paragraph metadata search: {e}")
             traceback.print_exc()
 
@@ -1195,7 +1219,10 @@ class GraphSearchTool(CodedTool):
         term_mappings = {
             "mitigation co-benefits": ["co-benefits from mitigation", "mitigation benefits", "ancillary benefits"],
             "adaptation action": ["adaptation activities", "adaptation measures", "adaptation efforts"],
-            "economic diversification": ["diversification plans", "economic transformation", "structural transformation"],
+            "economic diversification": [
+                "diversification plans", "economic transformation",
+                "structural transformation",
+            ],
             "additional information": ["further information", "supplementary information", "more detailed information"],
             "Party": ["country", "nation", "State Party", "Parties"],
             "must provide": ["shall provide", "required to provide", "obligation to provide", "provide"],
@@ -1293,7 +1320,9 @@ class GraphSearchTool(CodedTool):
         reverse = direction != "earliest"
         return sorted(results, key=get_year, reverse=reverse)
 
-    def _classify_episodes_founding(self, episode_results: List[Any]) -> Dict[str, Any]:
+    def _classify_episodes_founding(  # pylint: disable=too-many-locals
+        self, episode_results: List[Any],
+    ) -> Dict[str, Any]:
         """Classify episodes as founding or follow-up based on creation vs operational language.
 
         Scans episode content for creation verbs (establishes, creates, sets up) and
@@ -1330,10 +1359,18 @@ class GraphSearchTool(CodedTool):
 
             if creation_count > 0 and creation_count >= followup_count:
                 founding.append(episode)
-                print(f"  FOUNDING: Decision {decision_id} ({year}) - {name[:60]} [creation={creation_count}, followup={followup_count}]")
+                print(
+                    f"  FOUNDING: Decision {decision_id} ({year}) - "
+                    f"{name[:60]} [creation={creation_count}, "
+                    f"followup={followup_count}]"
+                )
             else:
                 followup.append(episode)
-                print(f"  FOLLOW-UP: Decision {decision_id} ({year}) - {name[:60]} [creation={creation_count}, followup={followup_count}]")
+                print(
+                    f"  FOLLOW-UP: Decision {decision_id} ({year}) - "
+                    f"{name[:60]} [creation={creation_count}, "
+                    f"followup={followup_count}]"
+                )
 
         # Sort founding by year ascending (earliest first)
         founding = self._temporal_rerank(founding, "earliest") if founding else []
@@ -1342,7 +1379,10 @@ class GraphSearchTool(CodedTool):
         founding_ids = [getattr(e, 'metadata', {}).get('decision_id', '?') for e in founding if hasattr(e, 'metadata')]
         followup_ids = [getattr(e, 'metadata', {}).get('decision_id', '?') for e in followup if hasattr(e, 'metadata')]
 
-        summary = f"Found {len(founding)} founding decision(s): {founding_ids} and {len(followup)} follow-up decision(s): {followup_ids}"
+        summary = (
+            f"Found {len(founding)} founding decision(s): {founding_ids} "
+            f"and {len(followup)} follow-up decision(s): {followup_ids}"
+        )
 
         return {
             "founding_episodes": founding,
@@ -1382,8 +1422,8 @@ class GraphSearchTool(CodedTool):
 
         return results
 
-    async def _search_topic_timeline(
-        self, query: str, query_analysis: Dict[str, Any], limit: int = 20
+    async def _search_topic_timeline(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+        self, query: str, query_analysis: Dict[str, Any], limit: int = 20,
     ) -> List[str]:
         """Search for ALL decisions on a topic and present them chronologically.
 
@@ -1487,12 +1527,17 @@ class GraphSearchTool(CodedTool):
         for ref_id in list(backward_ids)[:5]:
             result = await self._search_by_decision(ref_id, f"decision {ref_id}")
             if result:
-                decisions.insert(0, (0, f"[EARLIER] Decision {ref_id} — Referenced by later decisions (search for full text)\n{result[:300]}"))
+                earlier_text = (
+                    f"[EARLIER] Decision {ref_id} — Referenced by "
+                    f"later decisions (search for full text)\n"
+                    f"{result[:300]}"
+                )
+                decisions.insert(0, (0, earlier_text))
 
         return [d[1] for d in decisions]
 
-    def _validate_citation(
-        self, claim: str, source_text: str, metadata: Dict[str, Any]
+    def _validate_citation(  # pylint: disable=too-many-locals
+        self, claim: str, source_text: str, metadata: Dict[str, Any],
     ) -> Dict[str, Any]:
         """
         Validate that a claim can be supported by the source text.
@@ -1575,7 +1620,9 @@ class GraphSearchTool(CodedTool):
 
         return claims
 
-    async def _format_facts(self, query: str, results: List[Any]) -> str:
+    async def _format_facts(  # pylint: disable=too-many-locals,too-many-branches
+        self, query: str, results: List[Any],
+    ) -> str:
         """
         Format general graph facts with SOURCE CITATIONS and connected node details.
 
@@ -1828,7 +1875,9 @@ class GraphSearchTool(CodedTool):
 
         return "\n".join(output_parts)
 
-    async def _format_episodes(self, query: str, results: List[Any]) -> str:
+    async def _format_episodes(  # pylint: disable=too-many-locals,too-many-branches
+        self, query: str, results: List[Any],
+    ) -> str:
         """
         Format episode nodes with primary source content and metadata.
 
@@ -1849,7 +1898,11 @@ class GraphSearchTool(CodedTool):
         # If truncating, divide budget evenly across episodes
         if needs_truncation and len(results) > 0:
             per_episode_limit = self.MAX_OUTPUT_CHARS // len(results)
-            print(f"Total content: {total_content_chars} chars > {self.MAX_OUTPUT_CHARS} limit. Truncating each episode to ~{per_episode_limit} chars.")
+            print(
+                f"Total content: {total_content_chars} chars > "
+                f"{self.MAX_OUTPUT_CHARS} limit. Truncating each "
+                f"episode to ~{per_episode_limit} chars."
+            )
         else:
             per_episode_limit = 0  # No limit
 

--- a/coded_tools/graph_rag/neo4j_injestion.py
+++ b/coded_tools/graph_rag/neo4j_injestion.py
@@ -660,7 +660,7 @@ class Neo4jIngestionEnhanced(CodedTool):  # pylint: disable=too-many-instance-at
         followup_matches = len(self.FOLLOWUP_VERBS_RE.findall(check_text))
         if creation_matches > 0 and creation_matches >= followup_matches:
             return "founding"
-        elif followup_matches > creation_matches:
+        if followup_matches > creation_matches:
             return "follow_up"
         return "neutral"
 

--- a/docs/graph_rag.md
+++ b/docs/graph_rag.md
@@ -1,0 +1,445 @@
+# Graph RAG Agent Network
+
+## Overview
+
+The **Graph RAG** registry (`graph_rag.hocon`) implements a Graph-based Retrieval-Augmented Generation (RAG) agent network for answering questions about UNFCCC climate change documents. Unlike the other registries in this project (`paris_agreement`, `kyoto_protocol`, `cop`, `unfccc`) which use hierarchical AAOSA agents with `txt_loader` toolbox tools to load raw document files, Graph RAG uses a **knowledge graph** backed by [Neo4j](https://neo4j.com/) or [FalkorDB](https://www.falkordb.com/) and powered by the [Graphiti](https://github.com/getzep/graphiti) library for hybrid (vector + keyword) search.
+
+This approach enables:
+- **Cross-document relationship traversal** (e.g., "which decision first created X?" traces backward references)
+- **Temporal reasoning** across sessions and years
+- **Conference-type filtering** (CMA, COP/CP, CMP, SBI, SBSTA)
+- **Paragraph-level retrieval** from indexed metadata
+- **Founding vs. follow-up decision classification** to answer chronological governance questions
+
+## Architecture
+
+```
+User Query
+    |
+    v
++-------------------+
+|     GraphRAG      |  <-- Entry-point coordinator agent (gpt-4o)
+| (LLM orchestrator)|
++-------------------+
+    |
+    v
++-------------------+
+| graph_rag_expert  |  <-- Coded tool (Python class)
+| GraphSearchTool   |
++-------------------+
+    |
+    v
++-------------------+
+|    Graphiti Core   |  <-- Hybrid search engine (vector + keyword)
++-------------------+
+    |
+    +-------+-------+
+    |               |
+    v               v
++---------+   +-----------+
+|  Neo4j  |   | FalkorDB  |   <-- Graph database backends (auto-detected)
++---------+   +-----------+
+        |
+        v
++---------------------------+
+| UNFCCC Knowledge Graph    |
+| (COP, CMA, CMP, SBI,     |
+|  SBSTA decisions 2014-24) |
++---------------------------+
+```
+
+### Agent Network Structure
+
+| Agent | Type | Role |
+|-------|------|------|
+| `GraphRAG` | LLM agent (entry point) | Receives user queries, orchestrates search strategy, synthesizes answers with strict anti-hallucination rules |
+| `graph_rag_expert` | Coded tool (`GraphSearchTool`) | Executes multi-stage graph searches, analyzes queries, filters by conference type, classifies founding/follow-up decisions |
+
+### Comparison with Other Registries
+
+| Feature | `paris_agreement`, `cop`, `kyoto_protocol` | `graph_rag` |
+|---------|----------------------------------------------|-------------|
+| LLM model | `gpt-4.1` | `gpt-4o` |
+| Orchestration | AAOSA hierarchical sub-agents | Single coordinator + coded tool |
+| Document access | `txt_loader` toolbox (reads raw `.txt` files) | Knowledge graph (pre-indexed entities, relationships, episodes) |
+| Cross-document queries | Requires querying multiple sub-agents | Built-in relationship traversal and backward reference following |
+| Temporal reasoning | Manual (agent-level session awareness) | Automatic (temporal reranking, founding/follow-up classification) |
+| Conference filtering | Implicit (separate registries per conference) | Explicit (single registry filters by CMA/COP/CMP/SBI/SBSTA) |
+
+## Configuration
+
+### Registry File
+
+**File:** `registries/graph_rag.hocon`
+
+The registry is enabled in `registries/manifest.hocon`:
+```hocon
+{
+    "graph_rag.hocon": true
+}
+```
+
+### Environment Variables
+
+The coded tools load configuration from `coded_tools/graph_rag/.env`. The following variables control behavior:
+
+#### Database Connection (one required)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NEO4J_URI` | _(none)_ | Neo4j connection URI (e.g., `neo4j+s://...`). Takes priority over FalkorDB. |
+| `NEO4J_USER` | _(none)_ | Neo4j username |
+| `NEO4J_PASSWORD` | _(none)_ | Neo4j password |
+| `FALKORDB_HOST` | `localhost` | FalkorDB hostname. Used if `NEO4J_URI` is not set. |
+| `FALKORDB_PORT` | `6379` | FalkorDB port |
+| `FALKORDB_USERNAME` | _(none)_ | FalkorDB username (optional) |
+| `FALKORDB_PASSWORD` | _(none)_ | FalkorDB password (optional) |
+| `GRAPH_NAME` | `unfccc_knowledge_graph` | FalkorDB graph name |
+
+**Detection priority:** If `NEO4J_URI` is set, Neo4j is used. Otherwise, if `FALKORDB_HOST` is set, FalkorDB is used.
+
+#### LLM Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LLM_PROVIDER` | `openai` | LLM provider for Graphiti operations |
+| `LLM_BASE_URL` | `https://api.openai.com/v1` | LLM API base URL |
+| `LLM_API_KEY` | `OPENAI_API_KEY` | LLM API key environment variable name |
+| `LLM_CHOICE` | `gpt-4.1-mini` | Model used for graph search operations |
+| `INGESTION_LLM_CHOICE` | `gpt-4.1-nano` | Model used during document ingestion (faster/cheaper) |
+
+#### Embedding Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EMBEDDING_PROVIDER` | `openai` | Embedding provider |
+| `EMBEDDING_BASE_URL` | `https://api.openai.com/v1` | Embedding API base URL |
+| `EMBEDDING_API_KEY` | `OPENAI_API_KEY` | Embedding API key environment variable name |
+| `EMBEDDING_MODEL` | `text-embedding-3-small` | Embedding model |
+| `EMBEDDING_DIM` | `1536` | Embedding dimension |
+
+#### Ingestion Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATA_DIR` | `documents` | Directory containing UNFCCC `.txt` source files |
+| `BATCH_SIZE` | `10` | Number of episodes to ingest per batch |
+| `MAX_EPISODES` | `0` | Maximum episodes to ingest (`0` = unlimited) |
+| `CHUNK_SIZE` | `800` | Characters per chunk for document splitting |
+| `CHUNK_OVERLAP` | `150` | Overlap between chunks |
+| `MAX_CHUNK_SIZE` | `1500` | Maximum characters per chunk |
+| `ENABLE_DEMO_SEARCHES` | `false` | Run demo searches after ingestion |
+| `VERBOSE_LOGGING` | `false` | Enable detailed logging during ingestion |
+
+## Coded Tools
+
+All coded tools are located in `coded_tools/graph_rag/`.
+
+### GraphSearchTool
+
+**File:** `coded_tools/graph_rag/graph_search_tool.py`
+**Class:** `graph_rag.graph_search_tool.GraphSearchTool`
+**Extends:** `CodedTool` (neuro-san)
+
+The primary search tool used by the `graph_rag_expert` agent. Implements a multi-stage search pipeline with query analysis, conference filtering, and automatic founding/follow-up classification.
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | `string` | Yes | - | The search query. The tool has built-in query analysis, so the full user question should be passed. |
+| `limit` | `string` | No | `10` | Maximum number of results to return |
+| `search_type` | `enum` | No | `general` | Type of search (see below) |
+| `query_complexity` | `enum` | No | `medium` | Search depth level (see below) |
+
+**Search types:**
+
+| Value | Description |
+|-------|-------------|
+| `general` | Searches for general facts and relationships across the knowledge graph |
+| `entity` | Searches for entity nodes (countries, organizations, concepts, mechanisms) |
+| `relationship` | Searches for relationship edges between entities |
+| `episode` | Searches for primary source document content (episodes with exact wording) |
+
+**Query complexity levels:**
+
+| Value | Results | Use case |
+|-------|---------|----------|
+| `direct` | 1 | Specific decision, paragraph, or single fact lookup |
+| `medium` | 5 | Concept definitions, moderate topics |
+| `extensive` | 15 | Broad multi-faceted topics, governance evolution, timelines |
+
+#### Query Analysis
+
+The tool automatically analyzes each query to detect:
+
+- **Intent:** `factual`, `requirement`, `definition`, or `relationship`
+- **UNFCCC key concepts:** mitigation, adaptation, NDC, transparency, finance, loss and damage, technology transfer, capacity building, Article 6, global stocktake
+- **Temporal markers:** years, conference references (CMA 3, COP 26, etc.)
+- **Conference filter:** CMA (Paris Agreement), COP/CP (Convention), CMP (Kyoto Protocol), SBI, SBSTA
+- **Decision references:** e.g., "Decision 3/CMA.1"
+- **Paragraph references:** e.g., "para 123"
+- **Temporal direction:** `earliest` (for "first/originally created") or `latest`
+- **Timeline queries:** detected when asking about "all decisions", "evolution", "governance"
+- **Identification queries:** when a user describes a decision by content rather than number
+
+#### Multi-Stage Search Pipeline
+
+The search executes in up to 4 stages:
+
+```
+Stage 1: Entity Search
+    Find key concepts and entities matching the query
+        |
+        v
+Stage 2: Episode Search
+    Find primary source documents (with conference filtering)
+        |
+        +-- Stage 2B: Backward Reference Following
+        |   Trace "Recalling decision X" links to find founding decisions
+        |
+        +-- Stage 2C: Topic Timeline Search
+        |   Broad search for governance evolution queries
+        |
+        +-- Stage 2D: Founding/Follow-up Classification
+            Classify decisions as creating vs. developing
+        |
+        v
+Stage 3: Relationship Search
+    Find edges connecting entities
+        |
+        v
+Stage 4: Output Assembly
+    Priority-ordered output with truncation safety (40,000 char max)
+```
+
+#### Output Structure
+
+Results are assembled in priority order:
+
+1. **SPECIFIC DECISION** - Exact match by decision ID (e.g., "Decision 3/CMA.1")
+2. **SPECIFIC PARAGRAPHS** - Extracted paragraph content from metadata
+3. **FOUNDING DECISION(S) IDENTIFIED** - Decisions with creation language (ESTABLISHES, CREATES, LAUNCHES)
+4. **FOLLOW-UP DECISIONS** - Decisions that further develop/operationalize
+5. **EARLIER REFERENCED DECISIONS** - Decisions traced via backward reference following
+6. **COMPLETE DECISION TIMELINE** - Chronological list of all related decisions
+7. **PRIMARY SOURCE DOCUMENTS** - Episode content from the knowledge graph
+8. **RELEVANT ENTITIES AND CONCEPTS** - Entity nodes
+9. **RELATIONSHIPS AND CONNECTIONS** - Relationship edges
+
+#### Singleton Pattern
+
+`GraphSearchTool` uses class-level singletons for the Graphiti instance and database driver. This means:
+- The first invocation initializes the connection (which may take several seconds)
+- Subsequent invocations reuse the existing connection
+- The connection is shared across all agent invocations within the same process
+
+### FalkorDBIngestionEnhanced
+
+**File:** `coded_tools/graph_rag/falkordb_ingestion.py`
+**Class:** `graph_rag.falkordb_ingestion.FalkorDBIngestionEnhanced`
+**Extends:** `CodedTool` (neuro-san)
+
+Ingests UNFCCC climate decision documents from `.txt` files into FalkorDB using the Graphiti library. This is a **one-time data preparation step**, not part of the query-time agent network.
+
+#### Document Parsing
+
+The ingestion tool parses UNFCCC text files with the following structure:
+
+- **Primary sections:** Decisions and Resolutions (split by `Decision X/Y.Z` or `Resolution X/Y.Z` headers)
+- **Annexes:** Separated into distinct episodes (detected by `Annex` headers)
+- **Paragraphs:** Numbered paragraphs are extracted and stored in metadata for granular retrieval
+
+#### Episode Metadata
+
+Each ingested episode contains:
+
+| Field | Description |
+|-------|-------------|
+| `name` | Episode title (e.g., "Decision 3/CMA.1 - Matters relating to the implementation") |
+| `episode_body` | Full text content of the decision/annex section |
+| `source_description` | Human-readable source attribution |
+| `reference_time` | ISO timestamp derived from conference year |
+| `metadata.conference_type` | CMA, CMP, COP, SBI, or SBSTA |
+| `metadata.year` | Conference year |
+| `metadata.session` | Session number |
+| `metadata.location` | Conference location |
+| `metadata.fccc_reference` | FCCC document symbol (e.g., FCCC/PA/CMA/2018/3/Add.1) |
+| `metadata.decision_id` | Decision identifier (e.g., "3/CMA.1") |
+| `metadata.annex_id` | Annex identifier if applicable |
+| `metadata.paragraph_index` | JSON index mapping paragraph numbers to character offsets |
+
+#### Checkpoint Resume
+
+Ingestion supports checkpoint-based resumption. A checkpoint file (`.ingestion_checkpoint.txt`) tracks which episodes have been successfully added, allowing the process to resume after interruption without re-ingesting completed episodes.
+
+#### FalkorDB Monkey-Patches
+
+The ingestion module applies patches to three FalkorDB/Graphiti functions to prevent query timeout issues with large knowledge graphs:
+
+- `edge_search_filter_query_constructor` - Fixes edge search filter queries
+- `edge_fulltext_search` - Fixes full-text search on edges
+- `FalkorDriver.execute_query` - Adds timeout handling for graph queries
+
+### Neo4jIngestionEnhanced
+
+**File:** `coded_tools/graph_rag/neo4j_injestion.py`
+**Class:** `graph_rag.neo4j_injestion.Neo4jIngestionEnhanced`
+**Extends:** `CodedTool` (neuro-san)
+
+Functionally identical to `FalkorDBIngestionEnhanced` but targets Neo4j instead of FalkorDB. Uses the same document parsing, episode structure, and metadata extraction. Does not require the FalkorDB-specific monkey patches.
+
+### Constrained Prompts
+
+**File:** `coded_tools/graph_rag/constrained_prompts.py`
+
+Provides modified Graphiti prompt functions used **during ingestion** to prevent hallucination when building the knowledge graph. These replace Graphiti's default entity and relationship extraction prompts.
+
+#### `extract_text_constrained(context)`
+
+Modified entity extraction prompt. Key constraints:
+
+- Only extracts entities **explicitly mentioned** in the text
+- **Prohibits** extracting: conference body names (COP, CMA, CMP, SBI, SBSTA), session numbers, document headers
+- **Extracts:** structural references (Decision IDs, Articles, Annexes), named entities (countries, funds, organizations), climate concepts (mitigation, adaptation, NDC, finance, etc.)
+- **Annex separation rule:** Annex entities belong to the annex episode, not the parent decision
+
+#### `extract_edges_constrained(context)`
+
+Modified relationship/fact extraction prompt. Key constraints:
+
+- Only extracts relationships **explicitly stated** in the text
+- Categorizes relationships: structural, topical, financial, governance
+- Distinguishes **FOUNDING relationships** (ESTABLISHES, CREATES, LAUNCHES) from **FOLLOW-UP relationships** (FURTHER_DEVELOPS, EXPANDS, OPERATIONALIZES, REVIEWS)
+- This distinction is critical for the `GraphSearchTool` to answer "which decision FIRST created X" questions
+
+## Coordinator Agent Behavior
+
+The `GraphRAG` coordinator agent (the entry point) implements a detailed orchestration strategy defined in its HOCON instructions. Key behaviors:
+
+### 5-Stage Workflow
+
+1. **Query Analysis** - Restate the objective, identify entities/years/decision IDs/conference types
+2. **Knowledge Graph Exploration** - Always call `graph_rag_expert` first; treat the graph as the map of available information
+3. **Synthesis** - Merge graph results into a cohesive narrative with strict per-decision attribution
+4. **References** - Summarize prior decisions mentioned; call sub-agents for additional detail
+5. **Completeness Check** - For multi-stage governance questions, verify all phases are covered
+
+### Three Response Modes
+
+| Mode | Trigger | Behavior |
+|------|---------|----------|
+| **Specific Extraction** | User asks about a specific detail (e.g., "What does para 123 say?") | Brief, quote-only answer with exact text |
+| **Comprehensive Summary** | User asks what a decision is about (e.g., "Summarize Decision X") | Thorough structured list of all operative paragraphs |
+| **Decision Identification** | User describes a decision by content (e.g., "Which CMA decision created a network?") | Search broadly, identify all matching decisions with IDs and summaries |
+
+### Anti-Hallucination Rules
+
+The coordinator enforces strict anti-hallucination rules (highest priority):
+
+1. **Never invent decision numbers** - Only cite decision IDs that appear verbatim in search results
+2. **Never mix content across decisions** - Each decision's content is attributed only to that decision
+3. **Never attribute annex content to parent decisions** - Annex content is treated as separate
+4. **Every claim needs a source** - Must cite decision ID and paragraph number from search results
+5. **If unsure, say so** - Acknowledge gaps rather than filling them with outside knowledge
+
+### Conference Type Filtering
+
+| Abbreviation | Full Name | Decision Format |
+|-------------|-----------|-----------------|
+| CMA | Conference of the Parties serving as the meeting of the Parties to the Paris Agreement | Decision X/CMA.Y |
+| COP / CP | Conference of the Parties | Decision X/CP.Y |
+| CMP | Conference of the Parties serving as the meeting of the Parties to the Kyoto Protocol | Decision X/CMP.Y |
+| SBI | Subsidiary Body for Implementation | _(reports, not decisions)_ |
+| SBSTA | Subsidiary Body for Scientific and Technological Advice | _(reports, not decisions)_ |
+
+These are **completely separate** decision tracks. Decision 6/CMA.5 is not the same as Decision 6/CP.25.
+
+## Document Corpus
+
+The knowledge graph is built from UNFCCC decision documents covering:
+
+| Conference | Sessions | Years | Document Count |
+|------------|----------|-------|----------------|
+| CMA (Paris Agreement) | 1-6 | 2016-2024 | 18 files |
+| CMP (Kyoto Protocol) | 10-19 | 2014-2024 | 10 files |
+| COP (Conference of the Parties) | 20-29 | 2014-2024 | 22 files |
+| SBI (Implementation) | 40-61 | 2014-2024 | 13 files |
+| SBSTA (Scientific/Tech Advice) | 40-61 | 2014-2024 | 17 files |
+
+Source documents are stored in `documents/` as plain text files extracted from official UNFCCC PDF reports.
+
+## Setup and Usage
+
+### Prerequisites
+
+- Python 3.12 or 3.13
+- A running Neo4j or FalkorDB instance with the UNFCCC knowledge graph already ingested
+- OpenAI API key (for both the agent LLM and Graphiti's embedding/search operations)
+
+### 1. Install Dependencies
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Additional packages required for graph_rag (install separately):
+```bash
+pip install graphiti-core neo4j  # For Neo4j backend
+# or
+pip install graphiti-core falkordb  # For FalkorDB backend
+```
+
+### 2. Configure Environment
+
+Create or edit `coded_tools/graph_rag/.env` with your database credentials and API keys. See the [Environment Variables](#environment-variables) section above for all available options.
+
+### 3. Ingest Documents (One-Time)
+
+Before querying, the knowledge graph must be populated. This is done by running the ingestion tool, which can be invoked as a `CodedTool` through the neuro-san framework or directly.
+
+The ingestion process:
+1. Connects to the configured database (Neo4j or FalkorDB)
+2. Parses all `.txt` files in the `DATA_DIR` directory
+3. Splits documents into episodes (decisions, annexes, paragraphs)
+4. Uses Graphiti with [constrained prompts](#constrained-prompts) to extract entities and relationships
+5. Adds episodes to the knowledge graph with full metadata
+
+Ingestion supports **checkpoint resume** - if interrupted, it will skip already-ingested episodes on restart.
+
+### 4. Run the Agent Network
+
+```bash
+python -m run
+```
+
+Navigate to `http://localhost:4173/` and select the **graph_rag** agent network. Then ask questions about UNFCCC climate documents.
+
+### Sample Queries
+
+- "What does Decision 3/CMA.1 say about the Paris Agreement?"
+- "Which CMA decision first created the Santiago network for loss and damage?"
+- "How has the transparency framework evolved across CMA sessions?"
+- "What are the main differences between the Sharm el-Sheikh decision and the Baku decision on Article 6.2?"
+- "List all CMA decisions about climate finance"
+- "What does paragraph 43 of Decision 2/CMA.2 establish?"
+
+## File Reference
+
+```
+coded_tools/graph_rag/
+    __init__.py                  # Package init, exports GraphSearchTool
+    graph_search_tool.py         # Main search tool (~2050 lines)
+    falkordb_ingestion.py        # FalkorDB ingestion tool (~1790 lines)
+    neo4j_injestion.py           # Neo4j ingestion tool (~1645 lines)
+    constrained_prompts.py       # Anti-hallucination prompts for Graphiti (~394 lines)
+    .env                         # Environment configuration (not committed)
+    .ingestion_checkpoint.txt    # Ingestion resume checkpoint (auto-generated)
+
+registries/
+    graph_rag.hocon              # Agent network registry configuration
+    manifest.hocon               # Registry manifest (enables graph_rag)
+    aaosa_basic.hocon            # Shared AAOSA substitutions (included by graph_rag)
+```

--- a/registries/graph_rag.hocon
+++ b/registries/graph_rag.hocon
@@ -1,0 +1,146 @@
+{
+# Importing content from other HOCON files
+# The include keyword must be unquoted and followed by a quoted URL or file path.
+# File paths should be absolute or relative to the script's working directory, not the HOCON file location.
+# This "aaosa.hocon" file contains key-value pairs used for substitution.
+# Specifically, it provides values for the following keys:
+#   - aaosa_call
+#   - aaosa_command
+#   - aaosa_instructions
+# IMPORTANT:
+# Ensure that you run `python -m run` from the top level of the repository.
+# The path to this substitution file is relative to the top-level directory,
+# so running the script from elsewhere may result in file-not-found errors.
+    include "registries/aaosa_basic.hocon"
+    "llm_config": {
+        "model_name": "gpt-4o",
+    },
+   "instructions_prefix": """
+You are part of a graph_rag system of assistants.
+Only answer inquiries that are directly within your area of expertise.
+Do not try to help for other matters.
+Do not mention what you can NOT do. Only mention what you can do.
+""",
+"tools": [
+        # This is the agent network's entry point.
+        {
+            "name": "GraphRAG",
+            "function": {
+                "description": """
+A coordinating assistant that orchestrates graph-based and database queries to answer user inquiries about UNFCCC climate documents.
+                """
+            },
+            "instructions": ${instructions_prefix} """
+You are the RAG Coordinator responsible for orchestrating multi-stage retrieval to answer questions about UNFCCC climate documents.
+
+### Workflow
+1. **Initial Query Analysis**
+   - Receive the user’s question and restate the objective in your own words.
+   - Identify entities, years, decision IDs, or conference types that will guide the search.
+
+2. **Stage 1 – Knowledge Graph Exploration**
+   - Always call the Knowledge Graph Agent first.
+   - Use the graph to surface relationships, entities, and temporal facts.
+   - Capture document names, decision IDs, conference types, and years provided by the graph.
+   - Treat the knowledge graph as the map that shows what information exists and where it resides.
+
+3. **Stage 2 – Synthesis**
+   - Merge all graph insights (and any downstream retrieval results) into a cohesive narrative.
+   - Explain how the cited documents and decisions relate to the user’s question.
+   - Provide explicit citations with document names, decision IDs, and years.
+
+4. **Stage 3 – References and Prior Decisions**
+   - If you mention a prior decision, summarize it in one sentence.
+   - Call sub-agents whenever additional detail is required to complete the reference.
+
+### Query Routing
+- Begin every task by invoking the Knowledge Graph Agent before turning to other tools.
+
+### Answer Requirements
+- Cite sources by naming the document and the specific fact drawn from it.
+- Highlight temporal context whenever information may be time-sensitive.
+- Emphasize relationships between conferences, decisions, and thematic concepts.
+- Re-query the graph rather than guessing when information is uncertain.
+
+### Response Style
+- Provide enough background for a reader unfamiliar with the documents.
+- Include the critical keywords from the user’s request.
+- Remain detailed, accurate, well structured, and concise.
+- Be transparent about every cited source.
+""" ${aaosa_instructions},
+            "tools": ["knowledge_graph_agent","graph_rag_expert"]
+        },
+        {
+            "name": "knowledge_graph_agent",
+            "function": ${aaosa_call},
+            "instructions": ${instructions_prefix} """
+You are the Knowledge Graph Agent responsible for exploring relationships and connections within the UNFCCC knowledge graph stored in FalkorDB.
+
+## Mission
+Map the entities (concepts, decisions, conferences, etc.) most relevant to the user’s query and describe how they connect through citations, references, and thematic links.
+
+## Tool Usage
+When invoked, call the GraphSearchTool with:
+- **query** (required): Free-form search text that targets relevant concepts.
+- **limit** (optional, default 10): Maximum number of rows to return.
+- **search_type** (optional, default "general"): Choose `"general"`, `"entity"`, or `"relationship"`.
+  * `"general"` – retrieve facts and relationships (recommended default).
+  * `"entity"` – retrieve detailed info for specific entities or concepts.
+  * `"relationship"` – retrieve connections between a source entity and a target entity.
+
+## Output Requirements
+Tailor the response to the selected `search_type`:
+- **General search:** Provide relationship facts plus the connected entity details.
+- **Entity search:** Provide entity nodes with properties, summaries, and connections.
+- **Relationship search:** Provide relationship edges with source and target details.
+
+Every result must include entity names, summaries (when available), relationship types, and any document references (titles, decision IDs, years, conference types).
+
+## When to Use
+- Understanding how concepts relate to each other.
+- Identifying which documents cite or reference one another.
+- Exploring thematic connections spanning multiple conferences.
+- Surfacing promising documents and decision IDs before deep retrieval.
+
+## Collaboration
+- Deliver a concise “map” for the coordinator that states:
+  1. The relevant entities or concepts.
+  2. How those entities connect (relationship type and direction).
+  3. Which documents or decisions anchor the information.
+  4. Additional related topics that deserve follow-up.
+- Pass these findings to the coordinator so they can run targeted PostgreSQL queries for document content.
+- Always return document names, decision IDs, conference types, and years whenever the graph supplies them.
+""",
+            "tools": ["graph_rag_expert"]
+        },
+        {
+            "name": "graph_rag_expert",
+            "function": {
+                "description": """Search the UNFCCC knowledge graph for entities, relationships, and document connections.
+                Return entity information, relationship facts, and document links so downstream agents understand how the concepts relate.""",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "The search query to find relevant entities and relationships in the knowledge graph"
+                        },
+                        "limit": {
+                            "type": "string",
+                            "description": "Maximum number of results to return",
+                            "default": 10
+                        },
+                        "search_type": {
+                            "type": "string",
+                            "description": "Type of search: 'general' for facts and relationships, 'entity' for specific entities/concepts, 'relationship' for connections between entities (default: 'general')",
+                            "enum": ["general", "entity", "relationship"],
+                            "default": "general"
+                        }
+                    },
+                    "required": ["query"]
+                }
+            },
+            "class": "graph_rag.graph_search_tool.GraphSearchTool"
+        },
+]
+}

--- a/registries/manifest.hocon
+++ b/registries/manifest.hocon
@@ -3,5 +3,5 @@
     "paris_agreement.hocon": true,
     "cop.hocon": true,
     "unfccc.hocon": true,
-    "graph_rag.hocon": false
+    "graph_rag.hocon": true
 }

--- a/registries/manifest.hocon
+++ b/registries/manifest.hocon
@@ -3,4 +3,5 @@
     "paris_agreement.hocon": true,
     "cop.hocon": true,
     "unfccc.hocon": true,
+    "graph_rag.hocon": false
 }


### PR DESCRIPTION
## Summary

Adds a complete Graph RAG (Retrieval-Augmented Generation) module for querying UNFCCC climate decision documents via a knowledge graph (Neo4j or FalkorDB). The module includes:

- **`graph_search_tool.py`** (~2050 lines): Multi-stage search tool with query analysis, entity/relationship/episode search, decision lookup, paragraph extraction, temporal reranking, backward reference traversal, and citation validation.
- **`neo4j_injestion.py`** / **`falkordb_ingestion.py`**: Ingestion pipelines that parse UNFCCC `.txt` files, split decisions and annexes into sub-section episodes (with configurable threshold and overlap), and load them into the knowledge graph via Graphiti.
- **`constrained_prompts.py`**: Anti-hallucination entity and fact extraction prompts for Graphiti.
- **`graph_rag.hocon`**: Agent network configuration with a coordinator, knowledge graph agent, and search tool.
- **`docs/graph_rag.md`**: Full documentation covering architecture, setup, and usage.

The latest commit addresses pylint compliance in `graph_search_tool.py`:
- Removed 10 file-wide `pylint: disable` comments
- Fixed all `line-too-long` issues by wrapping long lines
- Fixed `consider-using-f-string` and `too-many-boolean-expressions`
- Added scoped `wrong-import-position` disable around necessary post-`load_dotenv` imports
- Added targeted inline disables on specific method definitions for structural issues (`too-many-locals`, `too-many-branches`, etc.)
- Added inline disables for `protected-access` (accessing `_search` on Graphiti client — no public API alternative) and `broad-exception-caught` (3 fallback error handlers)
- Both `graph_search_tool.py` and `neo4j_injestion.py` score **10.00/10** on pylint

## Review & Testing Checklist for Human

- [ ] **Verify search functionality end-to-end**: The search pipeline could not be tested against a live database in this session. Run the agent network with an ingested knowledge graph and test the benchmark queries from the docs (e.g., "What does Decision 3/CMA.1 say about the Paris Agreement?", "What are the four areas of work in the forum's work programme?")
- [ ] **Audit `_search` protected access** (5 call sites in `graph_search_tool.py`): This uses Graphiti's private `_search` method because the public `search()` API doesn't accept a `SearchConfig`. Confirm this is intentional and track for breakage on Graphiti upgrades.
- [ ] **Review inline pylint disables**: 9 methods have `too-many-locals`, 8 have `too-many-branches`, 8 have `too-many-statements`. These are structural issues that could be refactored (e.g., extracting helper methods) but were left as-is per user request to avoid functionality changes. Consider whether further refactoring is warranted.
- [ ] **Fix filename typo**: `neo4j_injestion.py` should be `neo4j_ingestion.py` (typo noted in conversation but not fixed in this PR).
- [ ] **Test ingestion checkpoint resume**: The ingestion tools support checkpoint-based resume. Verify that interrupting and restarting ingestion correctly skips already-processed episodes.

### Notes

- **No functionality changes** in the pylint fix commit — only code formatting and inline disable additions.
- **No tests included** — the module relies on integration testing with a live database and the neuro-san agent framework.
- **Hardcoded UNFCCC terminology** — the search tool contains extensive lists of climate-specific terms, decision patterns, and conference abbreviations. These are domain-specific and intentional.
- **Module-level `too-many-lines` disable** — `graph_search_tool.py` is 2049 lines (limit is 1000). This is a structural issue that would require splitting into multiple modules, which was out of scope for the pylint task.

---

**Link to Devin run:** https://app.devin.ai/sessions/018126e17cc04caab99c404bff8e6b6d  
**Requested by:** @shrushtiimehta